### PR TITLE
Support callable array steps in runChain method

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -807,7 +807,8 @@ final class Result
      */
     private function runChain(callable|object|array $next, mixed $input, array $meta): self
     {
-        $steps = is_array($next) ? $next : [$next];
+        // Allow callable arrays like [$service, 'handle'] to be treated as a single step
+        $steps = (! is_array($next) || is_callable($next)) ? [$next] : $next;
 
         $acc = $this;
         $current = $input;


### PR DESCRIPTION
Enhance the runChain method to accept callable arrays as single steps, allowing for more flexible chaining of operations. This change simplifies the handling of callable arrays without splitting them into multiple steps.