### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Maxiviper117/result-flow/security/code-scanning/3](https://github.com/Maxiviper117/result-flow/security/code-scanning/3)

In general, the fix is to add an explicit `permissions` section that grants only the minimal required scopes to the `GITHUB_TOKEN`. For this workflow, the steps only need to read repository contents to check out code; they do not need to write to the repo or interact with issues/PRs. Therefore, we can safely set `contents: read` as the workflow‑ or job‑level permissions.

The best minimal change without altering functionality is to add a `permissions` block at the root level (so it applies to all jobs) just after `concurrency:` (or just after `name:` / `on:`—placement among top‑level keys is flexible). We will set:

```yaml
permissions:
  contents: read
```

This ensures the `GITHUB_TOKEN` used by `actions/checkout@v5` can read repository contents, while preventing unnecessary write permissions. No additional imports or external tools are required; this is a pure workflow‑YAML change in `.github/workflows/run-tests.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
