### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -1,4 +1,6 @@
 name: Rector
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Maxiviper117/result-flow/security/code-scanning/2](https://github.com/Maxiviper117/result-flow/security/code-scanning/2)

In general, the fix is to explicitly restrict the GITHUB_TOKEN permissions for this workflow to the minimum required, instead of inheriting potentially broader repository or organization defaults. For a Rector dry-run that only checks PHP code and composer dependencies, read access to repository contents is sufficient; no write-level scopes are needed.

The best minimal change is to add a `permissions:` block at the workflow root (top level), just under the `name:` line and before `on:`. This will apply to all jobs in this workflow (currently just `rector`) and avoids modifying the job logic or steps. Set `contents: read` so checkout can still read the repository, and leave out any write or extra scopes since they are not used by the steps shown. No imports or additional methods are needed because this is just a YAML configuration change.

Concretely, in `.github/workflows/rector.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Rector`). No other lines need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
