### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,4 +1,7 @@
 name: PHPStan
+permissions:
+  contents: read
+  packages: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Maxiviper117/result-flow/security/code-scanning/1](https://github.com/Maxiviper117/result-flow/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` section either at the top level of the workflow or inside the `phpstan` job so that the `GITHUB_TOKEN` is limited to the least privilege it needs. For this workflow, the job only needs to read the repository contents to check out the code and run PHPStan, and possibly read packages if Composer installs from GitHub Packages. It does not need to write to the repository, issues, or pull requests.

The best fix without changing existing functionality is to add a root-level `permissions` block (applies to all jobs) just below the workflow `name:` that restricts access to read-only scopes: at a minimum `contents: read`, and optionally `packages: read` if you want to be explicit about reading packages. This will ensure `actions/checkout` and dependency installation still work, while preventing unintended write operations. Concretely, edit `.github/workflows/phpstan.yml` to insert:

```yaml
permissions:
  contents: read
  packages: read
```

after line 1 (`name: PHPStan`). No new imports, methods, or further definitions are required; this is purely a YAML configuration change within the shown file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
