### PR TITLE
fix: (metaops): enable tapMeta two-arg callback null on failure

### DIFF
--- a/docs/concepts/metadata.md
+++ b/docs/concepts/metadata.md
@@ -32,6 +32,8 @@ $result = Result::ok($value, ['request_id' => 'r-1'])
 
 On `Ok`, `mapMeta(...)` and `mergeMeta(...)` may accept callbacks that also receive the current value as a second argument (callbacks receive metadata first).
 
+Note: When a callable accepts two parameters the library now passes the value as the second argument for `Ok` results and `null` for `Fail` results. Prefer an optional or nullable second parameter (e.g. `fn(array $meta, $value = null)` or `fn(array $meta, ?MyType $value = null)`) to handle both branches safely and avoid static analysis warnings.
+
 ## A useful rule
 
 If a step changes the result shape, decide whether metadata should be preserved or updated at the same time. Do not silently drop it.

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -22,6 +22,8 @@ logger()->info('safe-debug', $result->toDebugArray());
 - `mergeMeta(...)` to add keys.
 - `mapMeta(...)` to replace metadata.
 - `tapMeta(...)` to inspect metadata.
+ 
+Note: If your metadata callback accepts two parameters, the library will pass the flow value as the second argument for `Ok` results and `null` for `Fail` results. Use an optional/nullable second parameter to handle both branches safely (for example `fn(array $meta, $value = null)`).
 - `tap(...)`, `onSuccess(...)`, `inspect(...)`, `onFailure(...)`, and `inspectError(...)` for side effects.
 - `toDebugArray(...)` for log-safe output.
 

--- a/docs/kitchen-sink/state-and-metadata.md
+++ b/docs/kitchen-sink/state-and-metadata.md
@@ -150,6 +150,8 @@ use Maxiviper117\ResultFlow\Result;
 $result = Result::ok(42);
 
 $result = $result->tapMeta(fn (array $meta, $value = null) => logger()->debug('meta', compact('meta', 'value')));
+
+Note: Callbacks that accept two parameters will now receive the current value for `Ok` results and `null` for `Fail` results. To be explicit and avoid static analyzer warnings, prefer an optional/nullable second parameter (e.g. `fn(array $meta, $value = null)` or `fn(array $meta, ?MyType $value = null)`).
 ```
 
 ## mapMeta
@@ -169,6 +171,8 @@ mapMeta(callable $map): self
 - on `Ok`, the callback receives the current metadata and the value as the second argument
 - on `Fail`, the callback receives metadata only
 - the result keeps the same branch and new metadata
+
+Note: If the callback accepts two parameters, the library will pass the value as the second argument when the result is `Ok` and `null` when the result is `Fail`. Use an optional/nullable second parameter to handle both branches safely.
 
 Use it when the metadata shape itself should change.
 
@@ -202,6 +206,8 @@ mergeMeta(array|callable $meta): self
 
 - array input merges keys directly
 - callable input may inspect metadata, and on `Ok` also receives the current value as a second argument
+
+Note: As with `mapMeta`, when a callable is provided that accepts two parameters it will receive `(meta, value)` on `Ok` and `(meta, null)` on `Fail`. Prefer `fn(array $meta, $value = null)` or a nullable typed second parameter.
 
 Use it when you want to add a few keys without replacing the whole map.
 

--- a/docs/reference/metadata-debugging.md
+++ b/docs/reference/metadata-debugging.md
@@ -16,6 +16,8 @@ Returns the current metadata map.
 
 Observes metadata without changing the result. On `Ok`, the callback will be invoked with the metadata as the first argument and the success value as an optional second argument; on `Fail` the callback receives metadata only.
 
+Note: If the provided callable accepts two parameters the library will pass the value as the second argument for `Ok` and `null` for `Fail`. To be explicit and friendly to static analyzers prefer an optional/nullable second parameter, e.g. `fn(array $meta, $value = null)` or `fn(array $meta, ?MyType $value = null)`.
+
 ## `mapMeta(callable $map): Result`
 
 Replaces metadata with the callback output.
@@ -24,7 +26,7 @@ The argument is a callable only.
 
 On `Ok`, the callback receives the current metadata as the first argument and the current value as the second argument.
 
-On `Fail`, the callback receives metadata only.
+On `Fail`, the callback receives metadata only. When the callable accepts two arguments, the second argument will be `null` on `Fail`.
 
 ```php
 $result = $result->mapMeta(fn (array $meta, $value = null) => [
@@ -42,7 +44,7 @@ The argument may be either an array or a callable.
 
 On `Ok`, the callable receives the current metadata as the first argument and the current value as the second argument.
 
-On `Fail`, the callable receives metadata only.
+On `Fail`, the callable receives metadata only. When the callable accepts two arguments, the second argument will be `null` on `Fail`.
 
 ```php
 $result = $result->mergeMeta(fn (array $meta, $value = null) => [

--- a/examples/misc/metadata-value-aware-demo.php
+++ b/examples/misc/metadata-value-aware-demo.php
@@ -4,65 +4,38 @@ require __DIR__.'/../../vendor/autoload.php';
 
 use Maxiviper117\ResultFlow\Result;
 
-// Successful value path
-$result = Result::ok(['name' => 'Alice', 'roles' => ['admin', 'user']], ['request_id' => 'r-123'])
-    ->mapMeta(function (array $meta, array $value) {
-        return [
-            ...$meta,
-            'role_count' => count($value['roles']),
-            'name_tag' => strtolower($value['name']),
-        ];
-    })
-    ->mergeMeta(function (array $meta, array $value) {
-        return [
-            'description' => sprintf('User %s with %d roles', $value['name'], count($value['roles'])),
-        ];
-    });
+function randomResult(): Result
+{
+    if (random_int(0, 1) === 1) {
+        return Result::ok(['name' => 'Alice', 'roles' => ['admin', 'user']], ['request_id' => 'r-123']);
+    }
 
-echo "OK value example:\n";
-print_r($result->toArray());
+    return Result::fail('validation_failed', ['request_id' => 'r-456']);
+}
 
-// Failure path remains metadata-only
-$failed = Result::fail('validation_failed', ['request_id' => 'r-456'])
-    ->mergeMeta(function (array $meta) {
-        return ['debug_note' => 'Value unavailable for failed result.'];
-    })
-    ->mapMeta(function (array $meta) {
-        return [...$meta, 'handled' => true];
-    });
+// Random result path
+$result = randomResult();
 
-echo "\nFailed value example:\n";
-print_r($failed->toArray());
+if ($result->isOk()) {
+    echo "Result is OK\n";
+} else {
+    echo "Result is FAIL\n";
+}
 
-//  tapMeta
-
-echo "\nInside tapMeta callback on success:\n";
-$result->tapMeta(function (array $meta, array $value) {
-    print_r($meta);
-    print_r($value);
-    // convert to json for logging
-    $logEntry = json_encode([
-        ...$meta,
-        ...$value,
-    ]);
-    echo "Log entry: $logEntry\n";
+// Tap into metadata for logging or side effects
+$result->tapMeta(function (array $meta, $value) {
+    echo "Logging metadata: ".json_encode($meta)."\n";
+    echo "Value: ".json_encode($value)."\n";
 });
 
-echo "\nInside tapMeta callback on failure:\n";
-$failed->tapMeta(function (array $meta, $value) {
-    print_r($meta);
-
-    $payload = [
-        'meta' => $meta,
-        'value' => $value,
-    ];
-
-    echo 'JSON payload: '.json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)."\n";
+// Map metadata to transform it
+$result = $result->mapMeta(function (array $meta, $value) {
+    // Add a timestamp to the metadata
+    return array_merge($meta, ['timestamp' => time()]);
 });
-// if ($failed->isOk()) {
-//     echo "This won't run since the result is a failure.\n";
-// } else {
-//     $failed->tapMeta(function (array $meta, $value) {
-//         print_r($meta);
-//     });
-// }
+
+// Merge additional metadata
+$result = $result->mergeMeta(function (array $meta, $value) {
+    echo "Merging additional metadata based on value: ".json_encode($value)."\n";
+    return ['processed_by' => 'metadata-value-aware-demo.php'];
+});

--- a/examples/misc/metadata-value-aware-demo.php
+++ b/examples/misc/metadata-value-aware-demo.php
@@ -33,3 +33,36 @@ $failed = Result::fail('validation_failed', ['request_id' => 'r-456'])
 
 echo "\nFailed value example:\n";
 print_r($failed->toArray());
+
+//  tapMeta
+
+echo "\nInside tapMeta callback on success:\n";
+$result->tapMeta(function (array $meta, array $value) {
+    print_r($meta);
+    print_r($value);
+    // convert to json for logging
+    $logEntry = json_encode([
+        ...$meta,
+        ...$value,
+    ]);
+    echo "Log entry: $logEntry\n";
+});
+
+echo "\nInside tapMeta callback on failure:\n";
+$failed->tapMeta(function (array $meta, $value) {
+    print_r($meta);
+
+    $payload = [
+        'meta' => $meta,
+        'value' => $value,
+    ];
+
+    echo 'JSON payload: '.json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)."\n";
+});
+// if ($failed->isOk()) {
+//     echo "This won't run since the result is a failure.\n";
+// } else {
+//     $failed->tapMeta(function (array $meta, $value) {
+//         print_r($meta);
+//     });
+// }

--- a/examples/misc/metadata-value-aware-demo.php
+++ b/examples/misc/metadata-value-aware-demo.php
@@ -24,8 +24,8 @@ if ($result->isOk()) {
 
 // Tap into metadata for logging or side effects
 $result->tapMeta(function (array $meta, $value) {
-    echo "Logging metadata: ".json_encode($meta)."\n";
-    echo "Value: ".json_encode($value)."\n";
+    echo 'Logging metadata: '.json_encode($meta)."\n";
+    echo 'Value: '.json_encode($value)."\n";
 });
 
 // Map metadata to transform it
@@ -36,6 +36,7 @@ $result = $result->mapMeta(function (array $meta, $value) {
 
 // Merge additional metadata
 $result = $result->mergeMeta(function (array $meta, $value) {
-    echo "Merging additional metadata based on value: ".json_encode($value)."\n";
+    echo 'Merging additional metadata based on value: '.json_encode($value)."\n";
+
     return ['processed_by' => 'metadata-value-aware-demo.php'];
 });

--- a/src/Support/Traits/MetaOps.php
+++ b/src/Support/Traits/MetaOps.php
@@ -6,7 +6,6 @@ namespace Maxiviper117\ResultFlow\Support\Traits;
 
 use Maxiviper117\ResultFlow\Result;
 
-
 /**
  * Metadata manipulation helpers for Result.
  *
@@ -19,7 +18,7 @@ final class MetaOps
      * @template TFailure
      *
      * @param  Result<TSuccess, TFailure>  $result
-     * @param (callable(array<string,mixed>): mixed)|(callable(array<string,mixed>, TSuccess|null): mixed) $tap
+     * @param  (callable(array<string,mixed>): mixed)|(callable(array<string,mixed>, TSuccess|null): mixed)  $tap
      * @return Result<TSuccess, TFailure>
      */
     public static function tapMeta(Result $result, callable $tap): Result
@@ -100,9 +99,9 @@ final class MetaOps
      * @template TSuccess
      * @template TFailure
      *
-     * @param Result<TSuccess, TFailure> $result
-     * @param (callable(array<string,mixed>): mixed)|(callable(array<string,mixed>, TSuccess|null): mixed) $callback
-     * @param array<string,mixed> $meta
+     * @param  Result<TSuccess, TFailure>  $result
+     * @param  (callable(array<string,mixed>): mixed)|(callable(array<string,mixed>, TSuccess|null): mixed)  $callback
+     * @param  array<string,mixed>  $meta
      */
     private static function callMetaCallback(Result $result, callable $callback, array $meta): mixed
     {
@@ -114,6 +113,7 @@ final class MetaOps
 
         if ($ref->getNumberOfParameters() >= 2) {
             $value = $result->isOk() ? $result->value() : null;
+
             return $closure($meta, $value);
         }
 

--- a/src/Support/Traits/MetaOps.php
+++ b/src/Support/Traits/MetaOps.php
@@ -6,6 +6,7 @@ namespace Maxiviper117\ResultFlow\Support\Traits;
 
 use Maxiviper117\ResultFlow\Result;
 
+
 /**
  * Metadata manipulation helpers for Result.
  *
@@ -18,6 +19,7 @@ final class MetaOps
      * @template TFailure
      *
      * @param  Result<TSuccess, TFailure>  $result
+     * @param (callable(array<string,mixed>): mixed)|(callable(array<string,mixed>, TSuccess|null): mixed) $tap
      * @return Result<TSuccess, TFailure>
      */
     public static function tapMeta(Result $result, callable $tap): Result
@@ -49,7 +51,7 @@ final class MetaOps
      * @template TFailure
      *
      * @param  Result<TSuccess, TFailure>  $result
-     * @param  array<string,mixed>|callable  $meta
+     * @param  array<string,mixed>|(callable(array<string,mixed>): array<string,mixed>)|(callable(array<string,mixed>, TSuccess|null): array<string,mixed>)  $meta
      * @return Result<TSuccess, TFailure>
      */
     public static function mergeMeta(Result $result, array|callable $meta): Result
@@ -83,22 +85,38 @@ final class MetaOps
     }
 
     /**
+     * Invokes a metadata callback that can optionally receive the result value.
+     *
+     * Supported callback signatures:
+     * - fn(array<string,mixed> $meta): mixed
+     * - fn(array<string,mixed> $meta, TSuccess|null $value): mixed
+     *
+     * If the callback expects two or more parameters, the result value is passed
+     * as the second argument. For failed results, `null` is provided. This means
+     * `Ok(null)` and `Fail(...)` are indistinguishable from the callback’s perspective.
+     *
+     * The callable is converted to a Closure to enable reflection-based arity detection.
+     *
      * @template TSuccess
      * @template TFailure
      *
-     * @param  Result<TSuccess, TFailure>  $result
-     * @param  array<string,mixed>  $meta
+     * @param Result<TSuccess, TFailure> $result
+     * @param (callable(array<string,mixed>): mixed)|(callable(array<string,mixed>, TSuccess|null): mixed) $callback
+     * @param array<string,mixed> $meta
      */
     private static function callMetaCallback(Result $result, callable $callback, array $meta): mixed
     {
-        if (! $result->isOk()) {
-            return $callback($meta);
+        /** @var \Closure $closure */
+        $closure = \Closure::fromCallable($callback);
+
+        /** @var \ReflectionFunction $ref */
+        $ref = new \ReflectionFunction($closure);
+
+        if ($ref->getNumberOfParameters() >= 2) {
+            $value = $result->isOk() ? $result->value() : null;
+            return $closure($meta, $value);
         }
 
-        try {
-            return $callback($meta, $result->value());
-        } catch (\ArgumentCountError) {
-            return $callback($meta);
-        }
+        return $closure($meta);
     }
 }

--- a/tests/ResultCoreTest.php
+++ b/tests/ResultCoreTest.php
@@ -146,6 +146,26 @@ it('tapMeta observes metadata without changing the payload', function () {
     expect($r->unwrap())->toBe('ok');
 });
 
+it('tapMeta two-arg callback receives value on ok and null on fail', function () {
+    $observedOk = null;
+
+    Result::ok('present', ['a' => 1])
+        ->tapMeta(function (array $meta, $value) use (&$observedOk) {
+            $observedOk = $value;
+        });
+
+    expect($observedOk)->toBe('present');
+
+    $observedFail = 'unset';
+
+    Result::fail('err', ['a' => 2])
+        ->tapMeta(function (array $meta, $value) use (&$observedFail) {
+            $observedFail = $value;
+        });
+
+    expect($observedFail)->toBeNull();
+});
+
 it('mapMeta replaces metadata when needed', function () {
     $r = Result::fail('boom', ['code' => 500])
         ->mapMeta(fn ($meta) => ['code' => 501, 'handled' => true]);

--- a/tests/ResultCoreTest.php
+++ b/tests/ResultCoreTest.php
@@ -16,8 +16,8 @@ it('propagates types through map/then and unwrap', function () {
     $r = Result::ok(123);
 
     $r2 = $r
-        ->map(fn (int $n, array $meta) => (string) $n) // should become Result<string, Exception>
-        ->then(fn (string $s, array $meta) => strlen($s)); // returns int -> Result<int, Exception>
+        ->map(fn(int $n, array $meta) => (string) $n) // should become Result<string, Exception>
+        ->then(fn(string $s, array $meta) => strlen($s)); // returns int -> Result<int, Exception>
 
     $val = $r2->unwrap();
 
@@ -41,7 +41,7 @@ it('unwrapOr returns default on failure', function () {
 
 it('recover converts failure into success', function () {
     $r = Result::fail('oops')
-        ->recover(fn ($err, $meta) => 'fixed');
+        ->recover(fn($err, $meta) => 'fixed');
 
     expect($r->unwrap())->toBe('fixed');
 });
@@ -68,7 +68,7 @@ it('onSuccess and onFailure taps are called appropriately', function () {
 });
 
 it('of() wraps thrown exceptions into failure and returns success otherwise', function () {
-    $ok = Result::of(fn () => 5);
+    $ok = Result::of(fn() => 5);
     expect($ok->unwrap())->toBe(5);
 
     $fail = Result::of(function () {
@@ -79,14 +79,14 @@ it('of() wraps thrown exceptions into failure and returns success otherwise', fu
 });
 
 it('defer() returns success for plain values and null', function () {
-    expect(Result::defer(fn () => 5)->unwrap())->toBe(5);
-    expect(Result::defer(fn () => null)->isOk())->toBeTrue();
-    expect(Result::defer(fn () => null)->value())->toBeNull();
+    expect(Result::defer(fn() => 5)->unwrap())->toBe(5);
+    expect(Result::defer(fn() => null)->isOk())->toBeTrue();
+    expect(Result::defer(fn() => null)->value())->toBeNull();
 });
 
 it('defer() preserves returned result instances and metadata', function () {
-    $ok = Result::defer(fn () => Result::ok('done', ['source' => 'defer']));
-    $fail = Result::defer(fn () => Result::fail('nope', ['source' => 'defer-fail']));
+    $ok = Result::defer(fn() => Result::ok('done', ['source' => 'defer']));
+    $fail = Result::defer(fn() => Result::fail('nope', ['source' => 'defer-fail']));
 
     expect($ok->isOk())->toBeTrue();
     expect($ok->value())->toBe('done');
@@ -109,8 +109,8 @@ it('defer() converts thrown exceptions into failure with same instance', functio
 });
 
 it('defer() chains with then() like other constructors', function () {
-    $result = Result::defer(fn () => 5)
-        ->then(fn (int $value, array $meta) => $value * 2);
+    $result = Result::defer(fn() => 5)
+        ->then(fn(int $value, array $meta) => $value * 2);
 
     expect($result->isOk())->toBeTrue();
     expect($result->value())->toBe(10);
@@ -119,8 +119,8 @@ it('defer() chains with then() like other constructors', function () {
 it('then accepts an array of steps and folds sequentially', function () {
     $r = Result::ok(2)
         ->then([
-            fn ($v, $m) => $v + 3,
-            fn ($v, $m) => Result::ok($v * 2),
+            fn($v, $m) => $v + 3,
+            fn($v, $m) => Result::ok($v * 2),
         ]);
 
     expect($r->unwrap())->toBe(10);
@@ -128,7 +128,7 @@ it('then accepts an array of steps and folds sequentially', function () {
 
 it('mapError transforms the error payload', function () {
     $r = Result::fail('err')
-        ->mapError(fn ($e, $m) => new RuntimeException($e));
+        ->mapError(fn($e, $m) => new RuntimeException($e));
 
     expect($r->error())->toBeInstanceOf(RuntimeException::class);
 });
@@ -166,9 +166,29 @@ it('tapMeta two-arg callback receives value on ok and null on fail', function ()
     expect($observedFail)->toBeNull();
 });
 
+it('mapMeta and mergeMeta two-arg callbacks receive null value on fail', function () {
+    $mapValue = 'unset';
+    $mergeValue = 'unset';
+
+    Result::fail('boom', ['foo' => 'bar'])
+        ->mapMeta(function (array $meta, $value) use (&$mapValue) {
+            $mapValue = $value;
+            return $meta;
+        });
+
+    Result::fail('boom', ['foo' => 'bar'])
+        ->mergeMeta(function (array $meta, $value) use (&$mergeValue) {
+            $mergeValue = $value;
+            return [];
+        });
+
+    expect($mapValue)->toBeNull();
+    expect($mergeValue)->toBeNull();
+});
+
 it('mapMeta replaces metadata when needed', function () {
     $r = Result::fail('boom', ['code' => 500])
-        ->mapMeta(fn ($meta) => ['code' => 501, 'handled' => true]);
+        ->mapMeta(fn($meta) => ['code' => 501, 'handled' => true]);
 
     expect($r->isFail())->toBeTrue();
     expect($r->error())->toBe('boom');
@@ -185,14 +205,13 @@ it('mergeMeta merges additional metadata', function () {
 
 it('otherwise chains failure into success', function () {
     $r = Result::fail('nope')
-        ->otherwise(fn ($e, $m) => Result::ok('recovered'));
+        ->otherwise(fn($e, $m) => Result::ok('recovered'));
 
     expect($r->unwrap())->toBe('recovered');
 });
 
 it('then accepts objects with __invoke', function () {
-    $obj = new class
-    {
+    $obj = new class {
         public function __invoke($v, $m)
         {
             return Result::ok($v + 1);
@@ -204,16 +223,14 @@ it('then accepts objects with __invoke', function () {
 });
 
 it('then accepts objects with handle() and execute() methods', function () {
-    $handler = new class
-    {
+    $handler = new class {
         public function handle($v, $m)
         {
             return Result::ok($v + 2);
         }
     };
 
-    $executor = new class
-    {
+    $executor = new class {
         public function execute($v, $m)
         {
             // return a non-Result value to ensure auto-wrapping works
@@ -231,19 +248,19 @@ it('then accepts objects with handle() and execute() methods', function () {
 it('runChain handles arrays, exceptions, and value propagation', function () {
     // Array of steps: value should propagate through all
     $r = Result::ok(1)->then([
-        fn ($v, $m) => $v + 2, // 3
-        fn ($v, $m) => $v * 5, // 15
-        fn ($v, $m) => Result::ok($v - 4), // 11
+        fn($v, $m) => $v + 2, // 3
+        fn($v, $m) => $v * 5, // 15
+        fn($v, $m) => Result::ok($v - 4), // 11
     ]);
     expect($r->unwrap())->toBe(11);
 
     // Exception in a step: should convert to fail, meta should include failed_step
     $r2 = Result::ok(10)->then([
-        fn ($v, $m) => $v + 1,
+        fn($v, $m) => $v + 1,
         function ($v, $m) {
             throw new RuntimeException('fail here');
         },
-        fn ($v, $m) => $v * 2, // should not run
+        fn($v, $m) => $v * 2, // should not run
     ]);
     expect($r2->isFail())->toBeTrue();
     expect($r2->error())->toBeInstanceOf(RuntimeException::class);
@@ -252,7 +269,7 @@ it('runChain handles arrays, exceptions, and value propagation', function () {
     // Meta is preserved through steps
     $meta = ['foo' => 'bar'];
     $r3 = Result::ok(2, $meta)->then([
-        fn ($v, $m) => $v * 2,
+        fn($v, $m) => $v * 2,
     ]);
     expect($r3->meta())->toBe($meta);
 });
@@ -282,7 +299,7 @@ it('accepts callable array steps without splitting them', function () {
 
     $result = Result::ok(10, ['base' => true])
         ->then([$service, 'handle']) // should be treated as a single callable, not two steps
-        ->then(fn ($v, $m) => Result::ok($v * 2, $m));
+        ->then(fn($v, $m) => Result::ok($v * 2, $m));
 
     expect($result->isOk())->toBeTrue();
     expect($result->value())->toBe(30);
@@ -311,8 +328,7 @@ it('pipeline then() with a local NotifyAction that throws becomes failure and on
     $dto = new ResultCorePipelineDto('Another Test Product', 'ANOTHERSKU456', 2999, 'Another dummy product for testing.');
 
     // Local NotifyAction-like object that throws when invoked
-    $notify = new class
-    {
+    $notify = new class {
         public function __invoke(mixed $payload, array $meta = [])
         {
             throw new Exception('Notification failed');

--- a/tests/ResultCoreTest.php
+++ b/tests/ResultCoreTest.php
@@ -16,8 +16,8 @@ it('propagates types through map/then and unwrap', function () {
     $r = Result::ok(123);
 
     $r2 = $r
-        ->map(fn(int $n, array $meta) => (string) $n) // should become Result<string, Exception>
-        ->then(fn(string $s, array $meta) => strlen($s)); // returns int -> Result<int, Exception>
+        ->map(fn (int $n, array $meta) => (string) $n) // should become Result<string, Exception>
+        ->then(fn (string $s, array $meta) => strlen($s)); // returns int -> Result<int, Exception>
 
     $val = $r2->unwrap();
 
@@ -41,7 +41,7 @@ it('unwrapOr returns default on failure', function () {
 
 it('recover converts failure into success', function () {
     $r = Result::fail('oops')
-        ->recover(fn($err, $meta) => 'fixed');
+        ->recover(fn ($err, $meta) => 'fixed');
 
     expect($r->unwrap())->toBe('fixed');
 });
@@ -68,7 +68,7 @@ it('onSuccess and onFailure taps are called appropriately', function () {
 });
 
 it('of() wraps thrown exceptions into failure and returns success otherwise', function () {
-    $ok = Result::of(fn() => 5);
+    $ok = Result::of(fn () => 5);
     expect($ok->unwrap())->toBe(5);
 
     $fail = Result::of(function () {
@@ -79,14 +79,14 @@ it('of() wraps thrown exceptions into failure and returns success otherwise', fu
 });
 
 it('defer() returns success for plain values and null', function () {
-    expect(Result::defer(fn() => 5)->unwrap())->toBe(5);
-    expect(Result::defer(fn() => null)->isOk())->toBeTrue();
-    expect(Result::defer(fn() => null)->value())->toBeNull();
+    expect(Result::defer(fn () => 5)->unwrap())->toBe(5);
+    expect(Result::defer(fn () => null)->isOk())->toBeTrue();
+    expect(Result::defer(fn () => null)->value())->toBeNull();
 });
 
 it('defer() preserves returned result instances and metadata', function () {
-    $ok = Result::defer(fn() => Result::ok('done', ['source' => 'defer']));
-    $fail = Result::defer(fn() => Result::fail('nope', ['source' => 'defer-fail']));
+    $ok = Result::defer(fn () => Result::ok('done', ['source' => 'defer']));
+    $fail = Result::defer(fn () => Result::fail('nope', ['source' => 'defer-fail']));
 
     expect($ok->isOk())->toBeTrue();
     expect($ok->value())->toBe('done');
@@ -109,8 +109,8 @@ it('defer() converts thrown exceptions into failure with same instance', functio
 });
 
 it('defer() chains with then() like other constructors', function () {
-    $result = Result::defer(fn() => 5)
-        ->then(fn(int $value, array $meta) => $value * 2);
+    $result = Result::defer(fn () => 5)
+        ->then(fn (int $value, array $meta) => $value * 2);
 
     expect($result->isOk())->toBeTrue();
     expect($result->value())->toBe(10);
@@ -119,8 +119,8 @@ it('defer() chains with then() like other constructors', function () {
 it('then accepts an array of steps and folds sequentially', function () {
     $r = Result::ok(2)
         ->then([
-            fn($v, $m) => $v + 3,
-            fn($v, $m) => Result::ok($v * 2),
+            fn ($v, $m) => $v + 3,
+            fn ($v, $m) => Result::ok($v * 2),
         ]);
 
     expect($r->unwrap())->toBe(10);
@@ -128,7 +128,7 @@ it('then accepts an array of steps and folds sequentially', function () {
 
 it('mapError transforms the error payload', function () {
     $r = Result::fail('err')
-        ->mapError(fn($e, $m) => new RuntimeException($e));
+        ->mapError(fn ($e, $m) => new RuntimeException($e));
 
     expect($r->error())->toBeInstanceOf(RuntimeException::class);
 });
@@ -173,12 +173,14 @@ it('mapMeta and mergeMeta two-arg callbacks receive null value on fail', functio
     Result::fail('boom', ['foo' => 'bar'])
         ->mapMeta(function (array $meta, $value) use (&$mapValue) {
             $mapValue = $value;
+
             return $meta;
         });
 
     Result::fail('boom', ['foo' => 'bar'])
         ->mergeMeta(function (array $meta, $value) use (&$mergeValue) {
             $mergeValue = $value;
+
             return [];
         });
 
@@ -188,7 +190,7 @@ it('mapMeta and mergeMeta two-arg callbacks receive null value on fail', functio
 
 it('mapMeta replaces metadata when needed', function () {
     $r = Result::fail('boom', ['code' => 500])
-        ->mapMeta(fn($meta) => ['code' => 501, 'handled' => true]);
+        ->mapMeta(fn ($meta) => ['code' => 501, 'handled' => true]);
 
     expect($r->isFail())->toBeTrue();
     expect($r->error())->toBe('boom');
@@ -205,13 +207,14 @@ it('mergeMeta merges additional metadata', function () {
 
 it('otherwise chains failure into success', function () {
     $r = Result::fail('nope')
-        ->otherwise(fn($e, $m) => Result::ok('recovered'));
+        ->otherwise(fn ($e, $m) => Result::ok('recovered'));
 
     expect($r->unwrap())->toBe('recovered');
 });
 
 it('then accepts objects with __invoke', function () {
-    $obj = new class {
+    $obj = new class
+    {
         public function __invoke($v, $m)
         {
             return Result::ok($v + 1);
@@ -223,14 +226,16 @@ it('then accepts objects with __invoke', function () {
 });
 
 it('then accepts objects with handle() and execute() methods', function () {
-    $handler = new class {
+    $handler = new class
+    {
         public function handle($v, $m)
         {
             return Result::ok($v + 2);
         }
     };
 
-    $executor = new class {
+    $executor = new class
+    {
         public function execute($v, $m)
         {
             // return a non-Result value to ensure auto-wrapping works
@@ -248,19 +253,19 @@ it('then accepts objects with handle() and execute() methods', function () {
 it('runChain handles arrays, exceptions, and value propagation', function () {
     // Array of steps: value should propagate through all
     $r = Result::ok(1)->then([
-        fn($v, $m) => $v + 2, // 3
-        fn($v, $m) => $v * 5, // 15
-        fn($v, $m) => Result::ok($v - 4), // 11
+        fn ($v, $m) => $v + 2, // 3
+        fn ($v, $m) => $v * 5, // 15
+        fn ($v, $m) => Result::ok($v - 4), // 11
     ]);
     expect($r->unwrap())->toBe(11);
 
     // Exception in a step: should convert to fail, meta should include failed_step
     $r2 = Result::ok(10)->then([
-        fn($v, $m) => $v + 1,
+        fn ($v, $m) => $v + 1,
         function ($v, $m) {
             throw new RuntimeException('fail here');
         },
-        fn($v, $m) => $v * 2, // should not run
+        fn ($v, $m) => $v * 2, // should not run
     ]);
     expect($r2->isFail())->toBeTrue();
     expect($r2->error())->toBeInstanceOf(RuntimeException::class);
@@ -269,7 +274,7 @@ it('runChain handles arrays, exceptions, and value propagation', function () {
     // Meta is preserved through steps
     $meta = ['foo' => 'bar'];
     $r3 = Result::ok(2, $meta)->then([
-        fn($v, $m) => $v * 2,
+        fn ($v, $m) => $v * 2,
     ]);
     expect($r3->meta())->toBe($meta);
 });
@@ -299,7 +304,7 @@ it('accepts callable array steps without splitting them', function () {
 
     $result = Result::ok(10, ['base' => true])
         ->then([$service, 'handle']) // should be treated as a single callable, not two steps
-        ->then(fn($v, $m) => Result::ok($v * 2, $m));
+        ->then(fn ($v, $m) => Result::ok($v * 2, $m));
 
     expect($result->isOk())->toBeTrue();
     expect($result->value())->toBe(30);
@@ -328,7 +333,8 @@ it('pipeline then() with a local NotifyAction that throws becomes failure and on
     $dto = new ResultCorePipelineDto('Another Test Product', 'ANOTHERSKU456', 2999, 'Another dummy product for testing.');
 
     // Local NotifyAction-like object that throws when invoked
-    $notify = new class {
+    $notify = new class
+    {
         public function __invoke(mixed $payload, array $meta = [])
         {
             throw new Exception('Notification failed');


### PR DESCRIPTION
Enhance the `tapMeta` method to allow callbacks that accept a second argument, which will be `null` for failed results. This change improves the handling of metadata in both success and failure scenarios.