### PR TITLE
feat: structured domain errors

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.4, 8.3, 8.2]
+        php: [8.4, 8.5]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ubuntu-latest

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -138,6 +138,7 @@ export default defineConfig({
               items: [
                 { text: 'ok', link: '/kitchen-sink/construction#ok' },
                 { text: 'fail', link: '/kitchen-sink/construction#fail' },
+                { text: 'failTagged', link: '/kitchen-sink/construction#failtagged' },
                 { text: 'failWithValue', link: '/kitchen-sink/construction#failwithvalue' },
                 { text: 'of', link: '/kitchen-sink/construction#of' },
                 { text: 'defer', link: '/kitchen-sink/construction#defer' },
@@ -186,6 +187,8 @@ export default defineConfig({
                 { text: 'mapError', link: '/kitchen-sink/chaining-and-recovery#maperror' },
                 { text: 'otherwise', link: '/kitchen-sink/chaining-and-recovery#otherwise' },
                 { text: 'catchException', link: '/kitchen-sink/chaining-and-recovery#catchexception' },
+                { text: 'matchError', link: '/kitchen-sink/chaining-and-recovery#matcherror' },
+                { text: 'catchError', link: '/kitchen-sink/chaining-and-recovery#catcherror' },
                 { text: 'recover', link: '/kitchen-sink/chaining-and-recovery#recover' },
                 { text: 'then', link: '/kitchen-sink/chaining-and-recovery#then' },
                 { text: 'flatMap', link: '/kitchen-sink/chaining-and-recovery#flatmap' },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - Public docs now live in `docs/` as a VitePress site with `concepts/`, `guides/`, `recipes/`, `reference/`, `kitchen-sink/`, `getting-started.md`, `faq.md`, and `laravel-boost.md`.
 - Static constructor APIs (`ok`, `fail`, `failWithValue`, `of`, `defer`, `retry`, `retryDefer`, `retrier`, `bracket`) must stay documented in the reference pages and reflected in Boost assets.
 - Internal helpers are organized under `src/Support/Traits/`, `src/Support/Operations/`, and `src/Support/Output/`.
+- Structured error helpers live under `src/Support/Errors/`; keep `DataTaggedError`, `ResultError`, `Cause`, and class-based `matchError()` / `catchError()` behavior aligned with docs, examples, and Boost assets.
 - `src/Support/Traits/` contains focused `Result` behavior traits (e.g., transform, unwrap, matching, taps, metadata ops).
 - `src/Support/Operations/` contains operation-style services/builders (e.g., retry, pipeline, batch mapping).
 - `src/Support/Output/` contains debug and serialization output helpers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@
 - Format check only (dry-run): `composer pint-test`
 - Static analysis: `composer analyse` (or `composer phpstan`)
 - Refactoring check: `composer rector-dry` (apply fixes with `composer rector`)
+- Preserve public named constructor arguments when Rector suggests constructor promotion.
 - Tests: `composer test` (or `composer test-coverage` when coverage is required)
 
 ## Python usage

--- a/README.md
+++ b/README.md
@@ -92,6 +92,36 @@ $result = Result::bracket(
 
 All batch callbacks use: `fn ($item, $key) => Result|value`.
 
+## Structured domain errors
+
+For domain-level failures that need a stable API shape and explicit branching, use
+subclasses of `DataTaggedError` and match them by class with `matchError(...)`
+or `catchError(...)`.
+
+```php
+use Maxiviper117\ResultFlow\Result;
+use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
+
+final class UserPersistError extends DataTaggedError
+{
+    public const CODE = 'E_USER_PERSIST';
+}
+
+$result = Result::fail(UserPersistError::from(
+    'Unable to persist user',
+    ['email' => 'dev@example.com'],
+));
+
+$message = $result->matchError(
+    [UserPersistError::class => fn (UserPersistError $e) => $e->code()],
+    onSuccess: fn ($value) => 'ok',
+    onUnhandled: fn ($error) => 'unhandled',
+);
+```
+
+Use `code()` for boundary serialization and external systems. Matching is based on
+the error class, not the string code.
+
 ## Laravel Boost
 
 This package ships Laravel Boost source assets so AI agents in downstream consumer apps can generate ResultFlow-aware code.

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     "require-dev": {
         "laravel/pint": "^1.14",
         "pestphp/pest": "^3.0",
-        "rector/rector": "^2.3",
-        "phpstan/phpstan": "^2.0",
+        "rector/rector": "2.3.5",
+        "phpstan/phpstan": "2.1.37",
         "phpstan/extension-installer": "^1.4"
     },
     "autoload": {

--- a/docs/concepts/failure-handling.md
+++ b/docs/concepts/failure-handling.md
@@ -18,8 +18,36 @@ $result = Result::fail('timeout')
 - `mapError(...)` changes the failure payload.
 - `otherwise(...)` handles the failure branch and can either recover or keep failing.
 - `catchException(...)` handles failure values that are `Throwable` instances by class.
+- `matchError(...)` and `catchError(...)` handle structured domain errors that implement `ResultError`.
 - `recover(...)` always returns success.
 - `throwIfFail(...)` converts failure back into exception-style control flow.
+
+## Structured domain errors
+
+When failure is part of normal domain behavior, prefer named classes extending
+`DataTaggedError` over ad-hoc strings or arrays.
+
+```php
+use Maxiviper117\ResultFlow\Result;
+use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
+
+final class UserPersistError extends DataTaggedError
+{
+    public const CODE = 'E_USER_PERSIST';
+}
+
+$result = Result::fail(UserPersistError::from('Unable to save user'));
+
+$message = $result->matchError(
+    [UserPersistError::class => fn (UserPersistError $e) => $e->message()],
+    onSuccess: fn ($value) => 'ok',
+    onUnhandled: fn ($error) => 'unhandled',
+);
+```
+
+Use the class to distinguish one domain failure from another. The string `code()`
+is still useful for JSON output, logs, and external contracts, but class identity
+is the matching mechanism.
 
 ## How to think about it
 
@@ -28,6 +56,10 @@ Use `otherwise(...)` when the next step is still part of the Result flow.
 Use `recover(...)` only when you intentionally want to stop carrying the failure branch forward.
 
 Use `throwIfFail(...)` at a boundary that expects exceptions, such as a transaction closure.
+
+Use `catchException(...)` for infrastructure/library exceptions.
+
+Use `matchError(...)` / `catchError(...)` for class-based domain errors.
 
 ## Common mistakes
 

--- a/docs/concepts/failure-handling.md
+++ b/docs/concepts/failure-handling.md
@@ -18,7 +18,8 @@ $result = Result::fail('timeout')
 - `mapError(...)` changes the failure payload.
 - `otherwise(...)` handles the failure branch and can either recover or keep failing.
 - `catchException(...)` handles failure values that are `Throwable` instances by class.
-- `matchError(...)` and `catchError(...)` handle structured domain errors that implement `ResultError`.
+- `matchError(...)` finalizes structured `ResultError` failures by class.
+- `catchError(...)` recovers from structured `ResultError` failures by class while staying inside the `Result` flow.
 - `recover(...)` always returns success.
 - `throwIfFail(...)` converts failure back into exception-style control flow.
 
@@ -47,7 +48,16 @@ $message = $result->matchError(
 
 Use the class to distinguish one domain failure from another. The string `code()`
 is still useful for JSON output, logs, and external contracts, but class identity
-is the matching mechanism.
+is the matching mechanism. Handlers are checked in array order, so the first
+matching class wins.
+
+`matchError(...)` supports flexible callbacks:
+
+- error handlers may accept the matched error only, or the error plus metadata
+- `onSuccess` / `onUnhandled` may accept no arguments, the value/error only, or the value/error plus metadata
+
+`catchError(...)` uses the same flexible callback style for handlers and fallback.
+Each callback may return either a recovered success value or a full `Result`.
 
 ## How to think about it
 
@@ -59,7 +69,8 @@ Use `throwIfFail(...)` at a boundary that expects exceptions, such as a transact
 
 Use `catchException(...)` for infrastructure/library exceptions.
 
-Use `matchError(...)` / `catchError(...)` for class-based domain errors.
+Use `matchError(...)` / `catchError(...)` for class-based domain errors that
+implement `ResultError`.
 
 ## Common mistakes
 

--- a/docs/guides/error-normalization.md
+++ b/docs/guides/error-normalization.md
@@ -29,6 +29,31 @@ $result = Result::of(fn () => $gateway->send($payload))
 - it avoids mixing raw exceptions with structured failures
 - `of(...)` is the right entry point here when `$gateway->send(...)` returns a plain payload on success and throws on failure
 
+## Structured domain errors
+
+If you want the normalized error to remain explicit and class-matchable later in the
+flow, map the exception into a named `DataTaggedError` subclass instead of an array.
+
+```php
+use Maxiviper117\ResultFlow\Result;
+use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
+
+final class UpstreamTimeoutError extends DataTaggedError
+{
+    public const CODE = 'UPSTREAM_TIMEOUT';
+}
+
+$result = Result::of(fn () => $gateway->send($payload))
+    ->catchException([
+        RuntimeException::class => fn (RuntimeException $e, array $meta) => Result::fail(
+            UpstreamTimeoutError::from($e->getMessage(), ['operation' => $meta['operation'] ?? 'unknown'])
+        ),
+    ]);
+```
+
+That keeps the boundary payload predictable while allowing later `matchError(...)`
+or `catchError(...)` calls to branch by error class.
+
 If the upstream gateway may already return `Result::ok(...)` or `Result::fail(...)`, switch the entry point to `Result::defer(...)` so the upstream result is preserved instead of wrapped as a success value.
 
 ## Related pages

--- a/docs/guides/error-normalization.md
+++ b/docs/guides/error-normalization.md
@@ -52,7 +52,9 @@ $result = Result::of(fn () => $gateway->send($payload))
 ```
 
 That keeps the boundary payload predictable while allowing later `matchError(...)`
-or `catchError(...)` calls to branch by error class.
+or `catchError(...)` calls to branch by `ResultError` class. Those handlers can
+stay terse with `fn (UpstreamTimeoutError $e) => ...` or opt into metadata with
+`fn (UpstreamTimeoutError $e, array $meta) => ...`.
 
 If the upstream gateway may already return `Result::ok(...)` or `Result::fail(...)`, switch the entry point to `Result::defer(...)` so the upstream result is preserved instead of wrapped as a success value.
 

--- a/docs/kitchen-sink/chaining-and-recovery.md
+++ b/docs/kitchen-sink/chaining-and-recovery.md
@@ -8,17 +8,19 @@ This group covers the functions that transform the success or failure branch, th
 
 ## Quick Map
 
-| Function         | What it does                            |
-| ---------------- | --------------------------------------- |
-| `map`            | Transforms the success value            |
-| `ensure`         | Converts a false predicate into failure |
-| `mapError`       | Transforms the failure value            |
-| `otherwise`      | Runs only on failure and may recover    |
-| `catchException` | Matches Throwable failures by class     |
-| `recover`        | Converts failure into success           |
-| `then`           | Chains a step with exception capture    |
-| `flatMap`        | Alias of `then`                         |
-| `thenUnsafe`     | Chains a step without exception capture |
+| Function         | What it does                              |
+| ---------------- | ----------------------------------------- |
+| `map`            | Transforms the success value              |
+| `ensure`         | Converts a false predicate into failure   |
+| `mapError`       | Transforms the failure value              |
+| `otherwise`      | Runs only on failure and may recover      |
+| `catchException` | Matches Throwable failures by class       |
+| `matchError`     | Matches structured domain errors by class |
+| `catchError`     | Handles structured domain errors by class |
+| `recover`        | Converts failure into success             |
+| `then`           | Chains a step with exception capture      |
+| `flatMap`        | Alias of `then`                           |
+| `thenUnsafe`     | Chains a step without exception capture   |
 
 ## map
 
@@ -157,6 +159,43 @@ Use:
 $result = Result::fail(new InvalidArgumentException('bad input'))
     ->catchException([
         InvalidArgumentException::class => fn ($error) => Result::fail('normalized'),
+    ]);
+```
+
+## matchError
+
+`matchError(...)` handles structured domain errors by class.
+
+```php
+matchError(array $handlers, callable $onSuccess, callable $onUnhandled): mixed
+```
+
+Use it when failures are named `DataTaggedError` subclasses rather than raw strings,
+arrays, or infrastructure exceptions.
+
+```php
+$message = Result::fail(UserPersistError::from('Unable to save user'))
+    ->matchError(
+        [UserPersistError::class => fn (UserPersistError $e) => $e->code()],
+        onSuccess: fn ($value) => 'ok',
+        onUnhandled: fn ($error) => 'unhandled',
+    );
+```
+
+## catchError
+
+`catchError(...)` recovers or re-fails structured domain errors by class.
+
+```php
+catchError(array $handlers, ?callable $fallback = null): self
+```
+
+Use it when the failure path should stay inside the `Result` flow.
+
+```php
+$result = Result::fail(UserPersistError::from('Unable to save user'))
+    ->catchError([
+        UserPersistError::class => fn (UserPersistError $e) => 'retry-later',
     ]);
 ```
 

--- a/docs/kitchen-sink/chaining-and-recovery.md
+++ b/docs/kitchen-sink/chaining-and-recovery.md
@@ -8,19 +8,19 @@ This group covers the functions that transform the success or failure branch, th
 
 ## Quick Map
 
-| Function         | What it does                              |
-| ---------------- | ----------------------------------------- |
-| `map`            | Transforms the success value              |
-| `ensure`         | Converts a false predicate into failure   |
-| `mapError`       | Transforms the failure value              |
-| `otherwise`      | Runs only on failure and may recover      |
-| `catchException` | Matches Throwable failures by class       |
-| `matchError`     | Matches structured domain errors by class |
-| `catchError`     | Handles structured domain errors by class |
-| `recover`        | Converts failure into success             |
-| `then`           | Chains a step with exception capture      |
-| `flatMap`        | Alias of `then`                           |
-| `thenUnsafe`     | Chains a step without exception capture   |
+| Function         | What it does                                                    |
+| ---------------- | --------------------------------------------------------------- |
+| `map`            | Transforms the success value                                    |
+| `ensure`         | Converts a false predicate into failure                         |
+| `mapError`       | Transforms the failure value                                    |
+| `otherwise`      | Runs only on failure and may recover                            |
+| `catchException` | Matches Throwable failures by class                             |
+| `matchError`     | Finalizes structured `ResultError` failures by class            |
+| `catchError`     | Recovers or re-fails structured `ResultError` failures by class |
+| `recover`        | Converts failure into success                                   |
+| `then`           | Chains a step with exception capture                            |
+| `flatMap`        | Alias of `then`                                                 |
+| `thenUnsafe`     | Chains a step without exception capture                         |
 
 ## map
 
@@ -164,14 +164,22 @@ $result = Result::fail(new InvalidArgumentException('bad input'))
 
 ## matchError
 
-`matchError(...)` handles structured domain errors by class.
+`matchError(...)` finalizes structured `ResultError` failures by class.
 
 ```php
-matchError(array $handlers, callable $onSuccess, callable $onUnhandled): mixed
+matchError(array $errorHandlers, callable $onSuccess, callable $onUnhandled): mixed
 ```
 
+### Behavior:
+
+- handlers are checked in array order; the first matching class wins
+- handler callbacks may accept the error only, or the error plus metadata
+- `onSuccess` / `onUnhandled` may accept no arguments, the value/error only, or the value/error plus metadata
+- if the failure is not a `ResultError`, or no class matches, `onUnhandled` runs
+
 Use it when failures are named `DataTaggedError` subclasses rather than raw strings,
-arrays, or infrastructure exceptions.
+arrays, or infrastructure exceptions. Any `ResultError` implementation is valid;
+`DataTaggedError` is simply the common built-in choice.
 
 ```php
 $message = Result::fail(UserPersistError::from('Unable to save user'))
@@ -184,11 +192,19 @@ $message = Result::fail(UserPersistError::from('Unable to save user'))
 
 ## catchError
 
-`catchError(...)` recovers or re-fails structured domain errors by class.
+`catchError(...)` recovers or re-fails structured `ResultError` failures by class.
 
 ```php
 catchError(array $handlers, ?callable $fallback = null): self
 ```
+
+### Behavior:
+
+- handlers are checked in array order; the first matching class wins
+- handler and fallback callbacks may accept no arguments, the error only, or the error plus metadata
+- callbacks may return either a plain recovered success value or a `Result`
+- if no handler matches, fallback is used when provided
+- if no handler matches and no fallback exists, the original failure is preserved
 
 Use it when the failure path should stay inside the `Result` flow.
 

--- a/docs/kitchen-sink/construction.md
+++ b/docs/kitchen-sink/construction.md
@@ -12,6 +12,7 @@ This group covers the functions that create a result, retry work, or guard a res
 | --------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `ok`            | Creates a success result                                                                                           |
 | `fail`          | Creates a failure result                                                                                           |
+| `failTagged`    | Creates a failure result containing a structured `DataTaggedError`                                                 |
 | `failWithValue` | Creates a failure result and stores the rejected input in metadata                                                 |
 | `of`            | Runs a callback that returns a plain value or throws; returned `Result` values are wrapped as plain success values |
 | `defer`         | Runs a callback that may return a value, a `Result`, or throw; returned `Result` values are preserved              |
@@ -73,6 +74,17 @@ $result = Result::fail('Invalid state', ['step' => 'validate']);
 ```php
 failWithValue(mixed $error, mixed $failedValue, array $meta = []): self
 ```
+
+## failTagged
+
+`failTagged(...)` creates a failure with a structured `DataTaggedError`.
+
+```php
+failTagged(string $code, string $message, mixed $payload = null, array $meta = [], ?Cause $cause = null): self
+```
+
+Use it for quick structured failures. For named domain errors, prefer a subclass of
+`DataTaggedError` with a `CODE` constant and construct it via `::from(...)`.
 
 ### Inputs:
 

--- a/docs/reference/boundaries.md
+++ b/docs/reference/boundaries.md
@@ -19,11 +19,20 @@ Finishes the result by handling both branches explicitly.
 
 Handles Throwable failures by class, otherwise falls back to the unhandled callback.
 
+## `matchError(array $handlers, callable $onSuccess, callable $onUnhandled): mixed`
+
+Handles structured domain errors by class.
+
+- use this for `DataTaggedError` subclasses and other `ResultError` implementations
+- unlike `matchException(...)`, matching is based on named error classes, not exception classes from infrastructure
+- `code()` is for serialization/boundaries, not dispatch
+
 ## `unwrap(): mixed`
 
 Returns the success value or throws the failure.
 
 - if the failure is a `Throwable`, it is thrown directly
+- that includes `DataTaggedError`, because it is throwable
 - otherwise a `RuntimeException` is thrown
 
 ## `unwrapOr(mixed $default): mixed`
@@ -45,6 +54,9 @@ Returns the same result on success. Throws on failure.
 ## `toJson(int $options = 0): string`
 
 Serializes the raw array shape to JSON with `JSON_THROW_ON_ERROR`.
+
+When the failure implements `ResultError`, the error payload is normalized through
+its `toArray()` shape before encoding.
 
 ## `toXml(string $rootElement = 'result'): string`
 

--- a/docs/reference/boundaries.md
+++ b/docs/reference/boundaries.md
@@ -24,6 +24,10 @@ Handles Throwable failures by class, otherwise falls back to the unhandled callb
 Handles structured domain errors by class.
 
 - use this for `DataTaggedError` subclasses and other `ResultError` implementations
+- handlers are checked in array iteration order; the first matching class wins
+- matched handlers may accept the error only or the error plus metadata
+- `onSuccess` / `onUnhandled` may accept no arguments, the value/error only, or the value/error plus metadata
+- if the failure is not a `ResultError`, or no handler matches, `onUnhandled` runs
 - unlike `matchException(...)`, matching is based on named error classes, not exception classes from infrastructure
 - `code()` is for serialization/boundaries, not dispatch
 

--- a/docs/reference/construction.md
+++ b/docs/reference/construction.md
@@ -20,6 +20,37 @@ Creates a failure result.
 $result = Result::fail('Invalid state', ['step' => 'validate']);
 ```
 
+You can also pass a structured error object such as a `DataTaggedError` subclass
+when you want stable boundary serialization and class-based matching later.
+
+## `Result::failTagged(string $code, string $message, mixed $payload = null, array $meta = [], ?Cause $cause = null): Result`
+
+Creates a failure result containing a `DataTaggedError`.
+
+- useful for quick structured failures
+- good when you want predictable JSON/debug output
+- for named domain errors, prefer a subclass of `DataTaggedError` and construct it via `::from(...)`
+
+```php
+use Maxiviper117\ResultFlow\Result;
+
+$result = Result::failTagged('E_USER_PERSIST', 'Unable to save user', ['email' => 'dev@example.com']);
+```
+
+### Named structured errors
+
+```php
+use Maxiviper117\ResultFlow\Result;
+use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
+
+final class UserPersistError extends DataTaggedError
+{
+	public const CODE = 'E_USER_PERSIST';
+}
+
+$result = Result::fail(UserPersistError::from('Unable to save user', ['email' => 'dev@example.com']));
+```
+
 ## `Result::failWithValue(mixed $error, mixed $failedValue, array $meta = []): Result`
 
 Creates a failure result and stores the value that caused it in metadata under `failed_value`.

--- a/docs/reference/failure-handling.md
+++ b/docs/reference/failure-handling.md
@@ -25,6 +25,37 @@ Matches `Throwable` failures by class.
 - non-Throwable failure -> original result if no fallback is provided
 - handlers and fallback may return a plain value or a `Result`
 
+## `matchError(array $handlers, callable $onSuccess, callable $onUnhandled): mixed`
+
+Matches structured domain errors by class.
+
+- handlers are keyed by `DataTaggedError` / `ResultError` class name
+- unmatched structured errors fall through to `$onUnhandled`
+- string codes are not used for dispatch
+
+```php
+$message = $result->matchError(
+    [UserPersistError::class => fn (UserPersistError $e) => $e->code()],
+    onSuccess: fn ($value) => 'ok',
+    onUnhandled: fn ($error) => 'unhandled',
+);
+```
+
+## `catchError(array $handlers, ?callable $fallback = null): Result`
+
+Handles structured domain errors by class and keeps the flow inside `Result`.
+
+- handlers are keyed by `DataTaggedError` / `ResultError` class name
+- handlers may return a plain value or a `Result`
+- unmatched failures return unchanged when no fallback is provided
+- fallback also handles legacy non-`ResultError` failures
+
+```php
+$result = $result->catchError([
+    UserPersistError::class => fn (UserPersistError $e) => 'retry-later',
+]);
+```
+
 ## `recover(callable $fn): Result`
 
 Converts any failure into a success result.

--- a/docs/reference/failure-handling.md
+++ b/docs/reference/failure-handling.md
@@ -25,12 +25,15 @@ Matches `Throwable` failures by class.
 - non-Throwable failure -> original result if no fallback is provided
 - handlers and fallback may return a plain value or a `Result`
 
-## `matchError(array $handlers, callable $onSuccess, callable $onUnhandled): mixed`
+## `matchError(array $errorHandlers, callable $onSuccess, callable $onUnhandled): mixed`
 
 Matches structured domain errors by class.
 
-- handlers are keyed by `DataTaggedError` / `ResultError` class name
-- unmatched structured errors fall through to `$onUnhandled`
+- handlers are keyed by `ResultError` class name (including `DataTaggedError` subclasses)
+- handlers are checked in array iteration order; the first matching class wins
+- matched handlers may accept either `(TError)` or `(TError, array $meta)`
+- `onSuccess` and `onUnhandled` may accept `()`, `(valueOrError)`, or `(valueOrError, array $meta)`
+- if the failure is not a `ResultError`, or no class matches, `$onUnhandled` runs
 - string codes are not used for dispatch
 
 ```php
@@ -45,10 +48,13 @@ $message = $result->matchError(
 
 Handles structured domain errors by class and keeps the flow inside `Result`.
 
-- handlers are keyed by `DataTaggedError` / `ResultError` class name
-- handlers may return a plain value or a `Result`
+- handlers are keyed by `ResultError` class name (including `DataTaggedError` subclasses)
+- handlers are checked in array iteration order; the first matching class wins
+- handlers and fallback may accept `()`, `(error)`, or `(error, array $meta)`
+- each callback may return either a plain recovered success value or a `Result`
+- if the failure is not a `ResultError`, class handlers are skipped and fallback is used when provided
 - unmatched failures return unchanged when no fallback is provided
-- fallback also handles legacy non-`ResultError` failures
+- fallback can handle both unmatched structured errors and legacy non-`ResultError` failures
 
 ```php
 $result = $result->catchError([

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -21,3 +21,9 @@ This section is for exact lookup.
 - scan the signature
 - check the behavior notes and edge cases
 - jump back to the related concept page if you need the mental model
+
+Structured domain errors are documented across:
+
+- [Construction](/reference/construction) for `failTagged(...)` and named error creation
+- [Failure handling](/reference/failure-handling) for `matchError(...)` / `catchError(...)`
+- [Boundaries](/reference/boundaries) for serialization and finalization behavior

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -25,5 +25,5 @@ This section is for exact lookup.
 Structured domain errors are documented across:
 
 - [Construction](/reference/construction) for `failTagged(...)` and named error creation
-- [Failure handling](/reference/failure-handling) for `matchError(...)` / `catchError(...)`
+- [Failure handling](/reference/failure-handling) for `matchError(...)` / `catchError(...)` and flexible `ResultError` callbacks
 - [Boundaries](/reference/boundaries) for serialization and finalization behavior

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,19 @@ Suggested order if you are new:
 5. `examples\defer\bracket-test.php`
 6. `examples\batch\batch-map-demo.php`
 7. `examples\debug\debug-sanitization-demo.php`
+8. `examples\tagged-error-demo.php`
+
+## Structured error examples
+
+### `php examples\tagged-error-demo.php`
+
+Purpose:
+- Demonstrate structured domain errors with `DataTaggedError`, nested `Cause`, and class-based `matchError()` / `catchError()` handling.
+
+Concept:
+- Builds a failing `Result` with a structured error and nested cause.
+- Prints JSON and debug output so you can inspect the boundary shape.
+- Shows the recommended named-error pattern with subclasses defining a `CODE` constant and constructed via `::from(...)`.
 
 ## Construction examples
 

--- a/examples/tagged-error-demo.php
+++ b/examples/tagged-error-demo.php
@@ -1,0 +1,99 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use Maxiviper117\ResultFlow\Result;
+use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
+use Maxiviper117\ResultFlow\Support\Errors\Cause;
+
+// Minimal demo showing structured error, matching, and recovery
+$cause = new Cause('E_DB', 'Primary key violation');
+$err = new DataTaggedError('E_USER_PERSIST', 'Unable to create user', ['email' => 'jane@example.com'], $cause);
+$result = Result::fail($err);
+
+echo "JSON:\n".$result->toJson(JSON_PRETTY_PRINT)."\n\n";
+
+echo "Debug:\n";
+print_r($result->toDebugArray());
+
+// match by class
+$matched = $result->matchError([
+    DataTaggedError::class => fn(DataTaggedError $e) => 'matched:'.$e->code(),
+], fn() => 'ok', fn() => 'unhandled');
+
+echo "\nmatchError: $matched\n";
+
+// recover using catchError by class
+$recovered = $result->catchError([
+    DataTaggedError::class => fn(DataTaggedError $e) => 'recovered:'.$e->code(),
+]);
+
+echo "\ncatchError -> ";
+print_r($recovered->toArray());
+
+// --- Alternative opt-in: create a named domain error class and match by class ---
+class UserPersistError extends DataTaggedError
+{
+    public const CODE = 'E_USER_PERSIST';
+}
+
+$userErr = UserPersistError::from('Could not create user (named class)', ['email' => 'john@example.com']);
+$r3 = Result::fail($userErr);
+
+echo "\nNamed-class JSON:\n".$r3->toJson(JSON_PRETTY_PRINT)."\n\n";
+
+$matchByClass = $r3->matchError([
+    UserPersistError::class => fn(UserPersistError $e) => 'matched_named:'.$e->code(),
+], fn() => 'ok', fn() => 'unhandled');
+
+echo "matchError by named class: $matchByClass\n";
+
+// --- Add another named error and a function that may return either ---
+class AnotherUserError extends DataTaggedError
+{
+    public const CODE = 'E_USER_ALT';
+}
+
+/**
+ * Create a user (demo).
+ *
+ * @param bool $useAlternate If true, returns an error variant
+ * @return Result<array{id: int, email: string}, AnotherUserError|UserPersistError>
+ */
+function createUser(bool $useAlternate = false): Result
+{
+    if (!$useAlternate) {
+        return Result::fail(UserPersistError::from('User persist failed', ['step' => 'save']));
+    }
+
+    if ($useAlternate) {
+        return Result::fail(AnotherUserError::from('Alternate user error', ['step' => 'validate']));
+    }
+
+    // Simulate a successful creation path when not using the alternate error
+    return Result::ok(['id' => 123, 'email' => 'john@example.com']);
+}
+
+/** @var Result<array{id:int,email:string}, AnotherUserError|UserPersistError> $resA */
+$resA = createUser(false);
+/** @var Result<array{id:int,email:string}, AnotherUserError|UserPersistError> $resB */
+$resB = createUser(true);
+
+echo "\ncreateUser(false) -> ";
+print_r($resA->toArray());
+echo "createUser(true) -> ";
+print_r($resB->toArray());
+
+// Match either error by providing both classes
+$handleA = $resA->matchError([
+    UserPersistError::class => fn(UserPersistError $e) => 'handled_user_persist: '.$e->code(),
+    AnotherUserError::class => fn(AnotherUserError $e) => 'handled_another: '.$e->code(),
+], fn() => 'ok', fn() => 'unhandled');
+
+$handleB = $resB->matchError([
+    UserPersistError::class => fn(UserPersistError $e) => 'handled_user_persist: '.$e->code(),
+    AnotherUserError::class => fn(AnotherUserError $e) => 'handled_another: '.$e->code(),
+], fn() => 'ok', fn() => 'unhandled');
+
+echo "\nmatch createUser(false): $handleA\n";
+echo "match createUser(true): $handleB\n";

--- a/examples/tagged-error-demo.php
+++ b/examples/tagged-error-demo.php
@@ -3,8 +3,8 @@
 require __DIR__.'/../vendor/autoload.php';
 
 use Maxiviper117\ResultFlow\Result;
-use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
 use Maxiviper117\ResultFlow\Support\Errors\Cause;
+use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
 
 // Minimal demo showing structured error, matching, and recovery
 $cause = new Cause('E_DB', 'Primary key violation');
@@ -18,14 +18,14 @@ print_r($result->toDebugArray());
 
 // match by class
 $matched = $result->matchError([
-    DataTaggedError::class => fn(DataTaggedError $e) => 'matched:'.$e->code(),
-], fn() => 'ok', fn() => 'unhandled');
+    DataTaggedError::class => fn (DataTaggedError $e) => 'matched:'.$e->code(),
+], fn () => 'ok', fn () => 'unhandled');
 
 echo "\nmatchError: $matched\n";
 
 // recover using catchError by class
 $recovered = $result->catchError([
-    DataTaggedError::class => fn(DataTaggedError $e) => 'recovered:'.$e->code(),
+    DataTaggedError::class => fn (DataTaggedError $e) => 'recovered:'.$e->code(),
 ]);
 
 echo "\ncatchError -> ";
@@ -43,8 +43,8 @@ $r3 = Result::fail($userErr);
 echo "\nNamed-class JSON:\n".$r3->toJson(JSON_PRETTY_PRINT)."\n\n";
 
 $matchByClass = $r3->matchError([
-    UserPersistError::class => fn(UserPersistError $e) => 'matched_named:'.$e->code(),
-], fn() => 'ok', fn() => 'unhandled');
+    UserPersistError::class => fn (UserPersistError $e) => 'matched_named:'.$e->code(),
+], fn () => 'ok', fn () => 'unhandled');
 
 echo "matchError by named class: $matchByClass\n";
 
@@ -57,12 +57,12 @@ class AnotherUserError extends DataTaggedError
 /**
  * Create a user (demo).
  *
- * @param bool $useAlternate If true, returns an error variant
+ * @param  bool  $useAlternate  If true, returns an error variant
  * @return Result<array{id: int, email: string}, AnotherUserError|UserPersistError>
  */
 function createUser(bool $useAlternate = false): Result
 {
-    if (!$useAlternate) {
+    if (! $useAlternate) {
         return Result::fail(UserPersistError::from('User persist failed', ['step' => 'save']));
     }
 
@@ -81,19 +81,19 @@ $resB = createUser(true);
 
 echo "\ncreateUser(false) -> ";
 print_r($resA->toArray());
-echo "createUser(true) -> ";
+echo 'createUser(true) -> ';
 print_r($resB->toArray());
 
 // Match either error by providing both classes
 $handleA = $resA->matchError([
-    UserPersistError::class => fn(UserPersistError $e) => 'handled_user_persist: '.$e->code(),
-    AnotherUserError::class => fn(AnotherUserError $e) => 'handled_another: '.$e->code(),
-], fn() => 'ok', fn() => 'unhandled');
+    UserPersistError::class => fn (UserPersistError $e) => 'handled_user_persist: '.$e->code(),
+    AnotherUserError::class => fn (AnotherUserError $e) => 'handled_another: '.$e->code(),
+], fn () => 'ok', fn () => 'unhandled');
 
 $handleB = $resB->matchError([
-    UserPersistError::class => fn(UserPersistError $e) => 'handled_user_persist: '.$e->code(),
-    AnotherUserError::class => fn(AnotherUserError $e) => 'handled_another: '.$e->code(),
-], fn() => 'ok', fn() => 'unhandled');
+    UserPersistError::class => fn (UserPersistError $e) => 'handled_user_persist: '.$e->code(),
+    AnotherUserError::class => fn (AnotherUserError $e) => 'handled_another: '.$e->code(),
+], fn () => 'ok', fn () => 'unhandled');
 
 echo "\nmatch createUser(false): $handleA\n";
 echo "match createUser(true): $handleB\n";

--- a/examples/tagged-error-demo.php
+++ b/examples/tagged-error-demo.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__.'/../vendor/autoload.php';
 
 use Maxiviper117\ResultFlow\Result;
 use Maxiviper117\ResultFlow\Support\Errors\Cause;
@@ -33,7 +33,7 @@ final class UserValidationError extends DataTaggedError
 /**
  * Create a user for demo purposes.
  *
- * @param 'persist'|'validate'|'ok' $mode
+ * @param  'persist'|'validate'|'ok'  $mode
  * @return Result<array{id: int, email: string}, UserPersistError|UserValidationError>
  */
 function createUser(string $mode): Result
@@ -96,30 +96,30 @@ function createUser(string $mode): Result
 /** @var Result<array{id:int,email:string}, UserPersistError|UserValidationError> $persistResult */
 $persistResult = createUser('persist');
 
-echo "Persist failure JSON:\n" . $persistResult->toJson(JSON_PRETTY_PRINT) . "\n\n";
+echo "Persist failure JSON:\n".$persistResult->toJson(JSON_PRETTY_PRINT)."\n\n";
 
 echo "Persist failure debug:\n";
 print_r($persistResult->toDebugArray());
 
 $matchedPersist = $persistResult->matchError(
     [
-        UserPersistError::class => fn(UserPersistError $e) => 'matched persist: ' . $e->code(),
-        UserValidationError::class => fn(UserValidationError $e) => 'matched validation: ' . $e->code(),
+        UserPersistError::class => fn (UserPersistError $e) => 'matched persist: '.$e->code(),
+        UserValidationError::class => fn (UserValidationError $e) => 'matched validation: '.$e->code(),
     ],
-    fn($user) => 'ok: ' . $user['email'],
-    fn($error) => 'unhandled'
+    fn ($user) => 'ok: '.$user['email'],
+    fn ($error) => 'unhandled'
 );
 
 echo "\nmatchError (persist): {$matchedPersist}\n";
 
 $recoveredPersist = $persistResult->catchError(
     [
-        UserPersistError::class => fn(UserPersistError $e) => [
+        UserPersistError::class => fn (UserPersistError $e) => [
             'id' => 999,
             'email' => 'recovered-from-persist@example.com',
         ],
     ],
-    fn($error) => Result::fail($error)
+    fn ($error) => Result::fail($error)
 );
 
 echo "\ncatchError (persist) ->\n";
@@ -134,22 +134,22 @@ print_r($recoveredPersist->toArray());
 /** @var Result<array{id:int,email:string}, UserPersistError|UserValidationError> $validationResult */
 $validationResult = createUser('validate');
 
-echo "\nValidation failure JSON:\n" . $validationResult->toJson(JSON_PRETTY_PRINT) . "\n\n";
+echo "\nValidation failure JSON:\n".$validationResult->toJson(JSON_PRETTY_PRINT)."\n\n";
 
 $matchedValidation = $validationResult->matchError(
     [
-        UserPersistError::class => fn(UserPersistError $e) => 'matched persist: ' . $e->code(),
-        UserValidationError::class => fn(UserValidationError $e, array $meta) => 'matched validation: ' . $e->code(),
+        UserPersistError::class => fn (UserPersistError $e) => 'matched persist: '.$e->code(),
+        UserValidationError::class => fn (UserValidationError $e, array $meta) => 'matched validation: '.$e->code(),
     ],
-    fn($user) => 'ok: ' . $user['email'],
-    fn($error) => 'unhandled'
+    fn ($user) => 'ok: '.$user['email'],
+    fn ($error) => 'unhandled'
 );
 
 echo "matchError (validate): {$matchedValidation}\n";
 
 $recoveredValidation = $validationResult->catchError(
     [
-        UserValidationError::class => fn(UserValidationError $e) => [
+        UserValidationError::class => fn (UserValidationError $e) => [
             'id' => 1000,
             'email' => 'recovered-from-validation@example.com',
         ],
@@ -168,23 +168,23 @@ print_r($recoveredValidation->toArray());
 /** @var Result<array{id:int,email:string}, UserPersistError|UserValidationError> $okResult */
 $okResult = createUser('ok');
 
-echo "\nSuccess JSON:\n" . $okResult->toJson(JSON_PRETTY_PRINT) . "\n\n";
+echo "\nSuccess JSON:\n".$okResult->toJson(JSON_PRETTY_PRINT)."\n\n";
 
 $matchedOk = $okResult->matchError(
     [
-        UserPersistError::class => fn(UserPersistError $e) => 'matched persist: ' . $e->code(),
-        UserValidationError::class => fn(UserValidationError $e) => 'matched validation: ' . $e->code(),
+        UserPersistError::class => fn (UserPersistError $e) => 'matched persist: '.$e->code(),
+        UserValidationError::class => fn (UserValidationError $e) => 'matched validation: '.$e->code(),
     ],
-    fn($user) => 'ok user: ' . $user['email'],
-    fn($error) => 'unhandled'
+    fn ($user) => 'ok user: '.$user['email'],
+    fn ($error) => 'unhandled'
 );
 
 echo "matchError (ok): {$matchedOk}\n";
 
 $recoveredOk = $okResult->catchError(
     [
-        UserPersistError::class => fn(UserPersistError $e) => ['id' => 0, 'email' => 'should-not-run@example.com'],
-        UserValidationError::class => fn(UserValidationError $e) => ['id' => 0, 'email' => 'should-not-run@example.com'],
+        UserPersistError::class => fn (UserPersistError $e) => ['id' => 0, 'email' => 'should-not-run@example.com'],
+        UserValidationError::class => fn (UserValidationError $e) => ['id' => 0, 'email' => 'should-not-run@example.com'],
     ]
 );
 

--- a/examples/tagged-error-demo.php
+++ b/examples/tagged-error-demo.php
@@ -59,8 +59,7 @@ function createUser(string $mode): Result
         );
 
         return Result::fail(
-            new UserPersistError(
-                code: UserPersistError::CODE,
+            UserPersistError::from(
                 message: 'Unable to persist user',
                 payload: ['email' => 'jane@example.com'],
                 cause: $cause,
@@ -70,8 +69,7 @@ function createUser(string $mode): Result
 
     if ($mode === 'validate') {
         return Result::fail(
-            new UserValidationError(
-                code: UserValidationError::CODE,
+            UserValidationError::from(
                 message: 'User data is invalid',
                 payload: [
                     'email' => 'not-an-email',

--- a/examples/tagged-error-demo.php
+++ b/examples/tagged-error-demo.php
@@ -1,99 +1,192 @@
 <?php
 
-require __DIR__.'/../vendor/autoload.php';
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
 
 use Maxiviper117\ResultFlow\Result;
 use Maxiviper117\ResultFlow\Support\Errors\Cause;
 use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
 
-// Minimal demo showing structured error, matching, and recovery
-$cause = new Cause('E_DB', 'Primary key violation');
-$err = new DataTaggedError('E_USER_PERSIST', 'Unable to create user', ['email' => 'jane@example.com'], $cause);
-$result = Result::fail($err);
+/*
+|--------------------------------------------------------------------------
+| Named domain errors
+|--------------------------------------------------------------------------
+*/
 
-echo "JSON:\n".$result->toJson(JSON_PRETTY_PRINT)."\n\n";
-
-echo "Debug:\n";
-print_r($result->toDebugArray());
-
-// match by class
-$matched = $result->matchError([
-    DataTaggedError::class => fn (DataTaggedError $e) => 'matched:'.$e->code(),
-], fn () => 'ok', fn () => 'unhandled');
-
-echo "\nmatchError: $matched\n";
-
-// recover using catchError by class
-$recovered = $result->catchError([
-    DataTaggedError::class => fn (DataTaggedError $e) => 'recovered:'.$e->code(),
-]);
-
-echo "\ncatchError -> ";
-print_r($recovered->toArray());
-
-// --- Alternative opt-in: create a named domain error class and match by class ---
-class UserPersistError extends DataTaggedError
+final class UserPersistError extends DataTaggedError
 {
     public const CODE = 'E_USER_PERSIST';
 }
 
-$userErr = UserPersistError::from('Could not create user (named class)', ['email' => 'john@example.com']);
-$r3 = Result::fail($userErr);
-
-echo "\nNamed-class JSON:\n".$r3->toJson(JSON_PRETTY_PRINT)."\n\n";
-
-$matchByClass = $r3->matchError([
-    UserPersistError::class => fn (UserPersistError $e) => 'matched_named:'.$e->code(),
-], fn () => 'ok', fn () => 'unhandled');
-
-echo "matchError by named class: $matchByClass\n";
-
-// --- Add another named error and a function that may return either ---
-class AnotherUserError extends DataTaggedError
+final class UserValidationError extends DataTaggedError
 {
-    public const CODE = 'E_USER_ALT';
+    public const CODE = 'E_USER_VALIDATE';
 }
+
+/*
+|--------------------------------------------------------------------------
+| Demo function returning named error classes
+|--------------------------------------------------------------------------
+*/
 
 /**
- * Create a user (demo).
+ * Create a user for demo purposes.
  *
- * @param  bool  $useAlternate  If true, returns an error variant
- * @return Result<array{id: int, email: string}, AnotherUserError|UserPersistError>
+ * @param 'persist'|'validate'|'ok' $mode
+ * @return Result<array{id: int, email: string}, UserPersistError|UserValidationError>
  */
-function createUser(bool $useAlternate = false): Result
+function createUser(string $mode): Result
 {
-    if (! $useAlternate) {
-        return Result::fail(UserPersistError::from('User persist failed', ['step' => 'save']));
+    if ($mode === 'persist') {
+        $cause = new Cause(
+            code: 'E_DB',
+            message: 'Primary key violation',
+            metadata: [
+                'table' => 'users',
+                'constraint' => 'email_unique',
+            ],
+            causes: [
+                new Cause(
+                    code: 'E_SQL',
+                    message: 'SQL error 1062',
+                    metadata: [
+                        'sqlState' => '23000',
+                        'errorCode' => 1062,
+                    ],
+                ),
+            ],
+        );
+
+        return Result::fail(
+            new UserPersistError(
+                code: UserPersistError::CODE,
+                message: 'Unable to persist user',
+                payload: ['email' => 'jane@example.com'],
+                cause: $cause,
+            )
+        );
     }
 
-    if ($useAlternate) {
-        return Result::fail(AnotherUserError::from('Alternate user error', ['step' => 'validate']));
+    if ($mode === 'validate') {
+        return Result::fail(
+            new UserValidationError(
+                code: UserValidationError::CODE,
+                message: 'User data is invalid',
+                payload: [
+                    'email' => 'not-an-email',
+                    'field' => 'email',
+                ],
+            )
+        );
     }
 
-    // Simulate a successful creation path when not using the alternate error
-    return Result::ok(['id' => 123, 'email' => 'john@example.com']);
+    return Result::ok([
+        'id' => 123,
+        'email' => 'john@example.com',
+    ]);
 }
 
-/** @var Result<array{id:int,email:string}, AnotherUserError|UserPersistError> $resA */
-$resA = createUser(false);
-/** @var Result<array{id:int,email:string}, AnotherUserError|UserPersistError> $resB */
-$resB = createUser(true);
+/*
+|--------------------------------------------------------------------------
+| Example 1: Persist failure
+|--------------------------------------------------------------------------
+*/
 
-echo "\ncreateUser(false) -> ";
-print_r($resA->toArray());
-echo 'createUser(true) -> ';
-print_r($resB->toArray());
+/** @var Result<array{id:int,email:string}, UserPersistError|UserValidationError> $persistResult */
+$persistResult = createUser('persist');
 
-// Match either error by providing both classes
-$handleA = $resA->matchError([
-    UserPersistError::class => fn (UserPersistError $e) => 'handled_user_persist: '.$e->code(),
-    AnotherUserError::class => fn (AnotherUserError $e) => 'handled_another: '.$e->code(),
-], fn () => 'ok', fn () => 'unhandled');
+echo "Persist failure JSON:\n" . $persistResult->toJson(JSON_PRETTY_PRINT) . "\n\n";
 
-$handleB = $resB->matchError([
-    UserPersistError::class => fn (UserPersistError $e) => 'handled_user_persist: '.$e->code(),
-    AnotherUserError::class => fn (AnotherUserError $e) => 'handled_another: '.$e->code(),
-], fn () => 'ok', fn () => 'unhandled');
+echo "Persist failure debug:\n";
+print_r($persistResult->toDebugArray());
 
-echo "\nmatch createUser(false): $handleA\n";
-echo "match createUser(true): $handleB\n";
+$matchedPersist = $persistResult->matchError(
+    [
+        UserPersistError::class => fn(UserPersistError $e) => 'matched persist: ' . $e->code(),
+        UserValidationError::class => fn(UserValidationError $e) => 'matched validation: ' . $e->code(),
+    ],
+    fn($user) => 'ok: ' . $user['email'],
+    fn($error) => 'unhandled'
+);
+
+echo "\nmatchError (persist): {$matchedPersist}\n";
+
+$recoveredPersist = $persistResult->catchError(
+    [
+        UserPersistError::class => fn(UserPersistError $e) => [
+            'id' => 999,
+            'email' => 'recovered-from-persist@example.com',
+        ],
+    ],
+    fn($error) => Result::fail($error)
+);
+
+echo "\ncatchError (persist) ->\n";
+print_r($recoveredPersist->toArray());
+
+/*
+|--------------------------------------------------------------------------
+| Example 2: Validation failure
+|--------------------------------------------------------------------------
+*/
+
+/** @var Result<array{id:int,email:string}, UserPersistError|UserValidationError> $validationResult */
+$validationResult = createUser('validate');
+
+echo "\nValidation failure JSON:\n" . $validationResult->toJson(JSON_PRETTY_PRINT) . "\n\n";
+
+$matchedValidation = $validationResult->matchError(
+    [
+        UserPersistError::class => fn(UserPersistError $e) => 'matched persist: ' . $e->code(),
+        UserValidationError::class => fn(UserValidationError $e, array $meta) => 'matched validation: ' . $e->code(),
+    ],
+    fn($user) => 'ok: ' . $user['email'],
+    fn($error) => 'unhandled'
+);
+
+echo "matchError (validate): {$matchedValidation}\n";
+
+$recoveredValidation = $validationResult->catchError(
+    [
+        UserValidationError::class => fn(UserValidationError $e) => [
+            'id' => 1000,
+            'email' => 'recovered-from-validation@example.com',
+        ],
+    ]
+);
+
+echo "\ncatchError (validate) ->\n";
+print_r($recoveredValidation->toArray());
+
+/*
+|--------------------------------------------------------------------------
+| Example 3: Success path
+|--------------------------------------------------------------------------
+*/
+
+/** @var Result<array{id:int,email:string}, UserPersistError|UserValidationError> $okResult */
+$okResult = createUser('ok');
+
+echo "\nSuccess JSON:\n" . $okResult->toJson(JSON_PRETTY_PRINT) . "\n\n";
+
+$matchedOk = $okResult->matchError(
+    [
+        UserPersistError::class => fn(UserPersistError $e) => 'matched persist: ' . $e->code(),
+        UserValidationError::class => fn(UserValidationError $e) => 'matched validation: ' . $e->code(),
+    ],
+    fn($user) => 'ok user: ' . $user['email'],
+    fn($error) => 'unhandled'
+);
+
+echo "matchError (ok): {$matchedOk}\n";
+
+$recoveredOk = $okResult->catchError(
+    [
+        UserPersistError::class => fn(UserPersistError $e) => ['id' => 0, 'email' => 'should-not-run@example.com'],
+        UserValidationError::class => fn(UserValidationError $e) => ['id' => 0, 'email' => 'should-not-run@example.com'],
+    ]
+);
+
+echo "\ncatchError (ok) ->\n";
+print_r($recoveredOk->toArray());

--- a/rector.php
+++ b/rector.php
@@ -9,6 +9,7 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
 use Rector\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector;
 use Rector\Php74\Rector\Assign\NullCoalescingOperatorRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php80\Rector\FuncCall\ClassOnObjectRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
@@ -50,6 +51,7 @@ return RectorConfig::configure()
         AddClosureVoidReturnTypeWhereNoReturnRector::class,
         AddVoidReturnTypeWhereNoReturnRector::class,
         ArrayToFirstClassCallableRector::class,
+        ClassPropertyAssignToConstructorPromotionRector::class,
         ClassOnObjectRector::class,
         ClosureReturnTypeRector::class,
         NullCoalescingOperatorRector::class,

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -12,35 +12,46 @@
 
 - Use `Maxiviper117\ResultFlow\Result` when failure is expected and should be handled explicitly in normal control flow.
 - Prefer ResultFlow for multi-step workflows (validation, persistence, side effects, response mapping).
-- Use the kitchen-sink docs for a full method tour when you need to compare related APIs; the pages use a consistent quick-map + method-by-method structure, and the reference docs stay best for exact signatures or edge behavior.
-- Keep exception throwing for truly exceptional conditions; use `Result::fail(...)` for expected domain/application failures.
+- Use the kitchen-sink docs for a full method tour when you need to compare related APIs; the pages use a consistent
+quick-map + method-by-method structure, and the reference docs stay best for exact signatures or edge behavior.
+- Keep exception throwing for truly exceptional conditions; use `Result::fail(...)` for expected domain/application
+failures.
 - Use `Result::failWithValue(...)` when the input that triggered failure should stay visible in metadata.
-- Use `Result::of(...)` when a callback returns a plain value on success and throws on failure; it always wraps the callback return value as success.
-- Use `Result::defer(...)` when a callback may return either a plain value or another `Result`; it preserves returned `Result` instances instead of wrapping them.
-- Use `Result::retryDefer(...)` or `Result::retrier()` for transient retries, not for validation or deterministic business rules.
-- Use `Result::combineAll(...)` when aggregating existing `Result[]` and you need every failure preserved; if any input fails, it returns only the collected failures and no success values.
+- Use `Result::of(...)` when a callback returns a plain value on success and throws on failure; it always wraps the
+callback return value as success.
+- Use `Result::defer(...)` when a callback may return either a plain value or another `Result`; it preserves returned
+`Result` instances instead of wrapping them.
+- Use `Result::retryDefer(...)` or `Result::retrier()` for transient retries, not for validation or deterministic
+business rules.
+- Use `Result::combineAll(...)` when aggregating existing `Result[]` and you need every failure preserved; if any input
+fails, it returns only the collected failures and no success values.
+- Use `DataTaggedError` subclasses when you want distinct named domain error types that can be matched with
+`matchError()` / `catchError()` by class.
 
 ## Canonical flow shape
 
-- Start with `Result::ok($input, $meta)`, `Result::fail($error, $meta)`, `Result::of(fn () => ...)`, `Result::defer(fn () => ...)`, or `Result::bracket(...)` when resource safety is required.
+- Start with `Result::ok($input, $meta)`, `Result::fail($error, $meta)`, `Result::of(fn () => ...)`, `Result::defer(fn
+() => ...)`, or `Result::bracket(...)` when resource safety is required.
 - Compose steps with `->ensure(...)`, `->then(...)`, and `->otherwise(...)`.
 - Use `->thenUnsafe(...)` only when exception bubbling is the desired boundary behavior, such as transaction rollback.
 - Use `->recover(...)` only when you intentionally convert failure into success.
 - End branches explicitly with either:
-  - `->toResponse()` in Laravel HTTP flows, or
-  - `->match(onSuccess: ..., onFailure: ...)` for non-HTTP/custom boundaries.
+- `->toResponse()` in Laravel HTTP flows, or
+- `->match(onSuccess: ..., onFailure: ...)` for non-HTTP/custom boundaries.
 - Use `->matchException(...)` when the boundary needs Throwable-class-specific handling.
+- Use `->matchError(...)` and `->catchError(...)` for structured domain errors that implement `ResultError`; these
+methods match by class, not by string code.
 
 ```php
 use Maxiviper117\ResultFlow\Result;
 
 $result = Result::ok($request->validated(), ['request_id' => (string) $request->header('X-Request-Id')])
-    ->ensure(fn (array $input) => isset($input['email']), 'Email is required')
-    ->then(fn (array $input) => $userService->create($input))
-    ->otherwise(fn ($error, array $meta) => Result::fail([
-        'message' => (string) $error,
-        'request_id' => $meta['request_id'] ?? null,
-    ], $meta));
+->ensure(fn (array $input) => isset($input['email']), 'Email is required')
+->then(fn (array $input) => $userService->create($input))
+->otherwise(fn ($error, array $meta) => Result::fail([
+'message' => (string) $error,
+'request_id' => $meta['request_id'] ?? null,
+], $meta));
 
 return $result->toResponse();
 ```
@@ -48,38 +59,46 @@ return $result->toResponse();
 ## Metadata discipline
 
 - Metadata is part of the contract. Treat it as `array<string,mixed>`.
-- Preserve metadata across steps; when transforming failure, forward existing `$meta`.
-- Use stable keys like `request_id`, `trace_id`, `operation`, and `context`.
-- If a pipeline step throws, prefer the built-in `failed_step` metadata over ad-hoc duplicate step labels.
-- `mapMeta()` and `mergeMeta()` can inspect the current success value when the result is `Ok`.
-- `Result::retry(...)` and `Result::retryDefer(...)` can expose retry attempt metadata when the builder enables it.
-- Do not silently discard metadata inside `then`, `otherwise`, or `recover` handlers.
+    - Preserve metadata across steps; when transforming failure, forward existing `$meta`.
+    - Use stable keys like `request_id`, `trace_id`, `operation`, and `context`.
+    - If a pipeline step throws, prefer the built-in `failed_step` metadata over ad-hoc duplicate step labels.
+    - `mapMeta()` and `mergeMeta()` can inspect the current success value when the result is `Ok`.
+    - `Result::retry(...)` and `Result::retryDefer(...)` can expose retry attempt metadata when the builder enables it.
+    - Do not silently discard metadata inside `then`, `otherwise`, or `recover` handlers.
 
-## Laravel response and transaction patterns
+    ## Laravel response and transaction patterns
 
-- For HTTP endpoints, return `Result` from service/action layers and convert once at the edge with `->toResponse()`.
-- Keep `toResponse()` payloads JSON-encodable; the non-Laravel fallback serializes to a JSON string body and can fail on invalid encoding.
-- For transactions that must rollback on `Result` failure, call `->throwIfFail()` inside the transaction closure.
-- Map low-level errors to user-safe structures in `otherwise(...)`, while keeping diagnostic details in metadata.
-- Use `Result::retryDefer(...)` for transient operations that may return value/Result or throw.
-- Use `Result::bracket(...)` for acquire/use/release flows where cleanup must always run.
-- If you serialize to XML, remember tag names are normalized for XML safety; treat XML output as a transport format, not a lossless mirror of arbitrary array keys.
-- Use `toDebugArray()` for logs and diagnostics instead of `toArray()` when payloads may contain secrets or large strings.
+    - For HTTP endpoints, return `Result` from service/action layers and convert once at the edge with `->toResponse()`.
+    - Keep `toResponse()` payloads JSON-encodable; the non-Laravel fallback serializes to a JSON string body and can
+    fail on invalid encoding.
+    - For transactions that must rollback on `Result` failure, call `->throwIfFail()` inside the transaction closure.
+    - Map low-level errors to user-safe structures in `otherwise(...)`, while keeping diagnostic details in metadata.
+    - Use `Result::retryDefer(...)` for transient operations that may return value/Result or throw.
+    - Use `Result::bracket(...)` for acquire/use/release flows where cleanup must always run.
+    - If you serialize to XML, remember tag names are normalized for XML safety; treat XML output as a transport format,
+    not a lossless mirror of arbitrary array keys.
+    - Use `toDebugArray()` for logs and diagnostics instead of `toArray()` when payloads may contain secrets or large
+    strings.
 
-## Error payload conventions
+    ## Error payload conventions
 
-- Use predictable error payloads (`string` or structured array) and be consistent per workflow.
-- If using arrays, include at least a user-facing `message` key and forward correlation keys from metadata.
-- Avoid mixing many unrelated error shapes in the same chain unless the call site normalizes them.
+    - Use predictable error payloads (`string` or structured array) and be consistent per workflow.
+    - If using arrays, include at least a user-facing `message` key and forward correlation keys from metadata.
+    - Avoid mixing many unrelated error shapes in the same chain unless the call site normalizes them.
+    - Prefer named classes extending `DataTaggedError` for app/domain failures that need stable API payloads and
+    explicit branch handling.
+    - Treat `code()` as the stable domain/API identifier for structured errors; matching should be based on the error
+    class.
 
-## Type-safety defaults
+    ## Type-safety defaults
 
-- Prefer typed callback arguments and returns whenever concrete types are known.
-- Return `Result` from chain handlers when behavior is branch-aware; avoid unnecessary `mixed` widening.
-- Use only documented public `Result` methods.
+    - Prefer typed callback arguments and returns whenever concrete types are known.
+    - Return `Result` from chain handlers when behavior is branch-aware; avoid unnecessary `mixed` widening.
+    - Use only documented public `Result` methods.
 
-## Anti-patterns to avoid
+    ## Anti-patterns to avoid
 
-- Do not model expected validation/business failures only with thrown exceptions.
-- Do not drop metadata when converting one failure shape to another.
-- Do not leave a flow without explicit branch completion (`match`, `toResponse`, `unwrap*`, etc.) at the app boundary.
+    - Do not model expected validation/business failures only with thrown exceptions.
+    - Do not drop metadata when converting one failure shape to another.
+    - Do not leave a flow without explicit branch completion (`match`, `toResponse`, `unwrap*`, etc.) at the app
+    boundary.

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -61,46 +61,46 @@ return $result->toResponse();
 ## Metadata discipline
 
 - Metadata is part of the contract. Treat it as `array<string,mixed>`.
-    - Preserve metadata across steps; when transforming failure, forward existing `$meta`.
-    - Use stable keys like `request_id`, `trace_id`, `operation`, and `context`.
-    - If a pipeline step throws, prefer the built-in `failed_step` metadata over ad-hoc duplicate step labels.
-    - `mapMeta()` and `mergeMeta()` can inspect the current success value when the result is `Ok`.
-    - `Result::retry(...)` and `Result::retryDefer(...)` can expose retry attempt metadata when the builder enables it.
-    - Do not silently discard metadata inside `then`, `otherwise`, or `recover` handlers.
+- Preserve metadata across steps; when transforming failure, forward existing `$meta`.
+- Use stable keys like `request_id`, `trace_id`, `operation`, and `context`.
+- If a pipeline step throws, prefer the built-in `failed_step` metadata over ad-hoc duplicate step labels.
+- `mapMeta()` and `mergeMeta()` can inspect the current success value when the result is `Ok`.
+- `Result::retry(...)` and `Result::retryDefer(...)` can expose retry attempt metadata when the builder enables it.
+- Do not silently discard metadata inside `then`, `otherwise`, or `recover` handlers.
 
-    ## Laravel response and transaction patterns
+## Laravel response and transaction patterns
 
-    - For HTTP endpoints, return `Result` from service/action layers and convert once at the edge with `->toResponse()`.
-    - Keep `toResponse()` payloads JSON-encodable; the non-Laravel fallback serializes to a JSON string body and can
-    fail on invalid encoding.
-    - For transactions that must rollback on `Result` failure, call `->throwIfFail()` inside the transaction closure.
-    - Map low-level errors to user-safe structures in `otherwise(...)`, while keeping diagnostic details in metadata.
-    - Use `Result::retryDefer(...)` for transient operations that may return value/Result or throw.
-    - Use `Result::bracket(...)` for acquire/use/release flows where cleanup must always run.
-    - If you serialize to XML, remember tag names are normalized for XML safety; treat XML output as a transport format,
-    not a lossless mirror of arbitrary array keys.
-    - Use `toDebugArray()` for logs and diagnostics instead of `toArray()` when payloads may contain secrets or large
-    strings.
+- For HTTP endpoints, return `Result` from service/action layers and convert once at the edge with `->toResponse()`.
+- Keep `toResponse()` payloads JSON-encodable; the non-Laravel fallback serializes to a JSON string body and can
+fail on invalid encoding.
+- For transactions that must rollback on `Result` failure, call `->throwIfFail()` inside the transaction closure.
+- Map low-level errors to user-safe structures in `otherwise(...)`, while keeping diagnostic details in metadata.
+- Use `Result::retryDefer(...)` for transient operations that may return value/Result or throw.
+- Use `Result::bracket(...)` for acquire/use/release flows where cleanup must always run.
+- If you serialize to XML, remember tag names are normalized for XML safety; treat XML output as a transport format,
+not a lossless mirror of arbitrary array keys.
+- Use `toDebugArray()` for logs and diagnostics instead of `toArray()` when payloads may contain secrets or large
+strings.
 
-    ## Error payload conventions
+## Error payload conventions
 
-    - Use predictable error payloads (`string` or structured array) and be consistent per workflow.
-    - If using arrays, include at least a user-facing `message` key and forward correlation keys from metadata.
-    - Avoid mixing many unrelated error shapes in the same chain unless the call site normalizes them.
-    - Prefer named classes extending `DataTaggedError` for app/domain failures that need stable API payloads and
-        explicit branch handling.
-    - Treat `code()` as the stable domain/API identifier for structured errors; matching should be based on the error
-        class, with the first matching `matchError(...)` / `catchError(...)` handler winning in array order.
+- Use predictable error payloads (`string` or structured array) and be consistent per workflow.
+- If using arrays, include at least a user-facing `message` key and forward correlation keys from metadata.
+- Avoid mixing many unrelated error shapes in the same chain unless the call site normalizes them.
+- Prefer named classes extending `DataTaggedError` for app/domain failures that need stable API payloads and
+explicit branch handling.
+- Treat `code()` as the stable domain/API identifier for structured errors; matching should be based on the error
+class, with the first matching `matchError(...)` / `catchError(...)` handler winning in array order.
 
-    ## Type-safety defaults
+## Type-safety defaults
 
-    - Prefer typed callback arguments and returns whenever concrete types are known.
-    - Return `Result` from chain handlers when behavior is branch-aware; avoid unnecessary `mixed` widening.
-    - Use only documented public `Result` methods.
+- Prefer typed callback arguments and returns whenever concrete types are known.
+- Return `Result` from chain handlers when behavior is branch-aware; avoid unnecessary `mixed` widening.
+- Use only documented public `Result` methods.
 
-    ## Anti-patterns to avoid
+## Anti-patterns to avoid
 
-    - Do not model expected validation/business failures only with thrown exceptions.
-    - Do not drop metadata when converting one failure shape to another.
-    - Do not leave a flow without explicit branch completion (`match`, `toResponse`, `unwrap*`, etc.) at the app
-    boundary.
+- Do not model expected validation/business failures only with thrown exceptions.
+- Do not drop metadata when converting one failure shape to another.
+- Do not leave a flow without explicit branch completion (`match`, `toResponse`, `unwrap*`, etc.) at the app
+boundary.

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -40,7 +40,9 @@ fails, it returns only the collected failures and no success values.
 - `->match(onSuccess: ..., onFailure: ...)` for non-HTTP/custom boundaries.
 - Use `->matchException(...)` when the boundary needs Throwable-class-specific handling.
 - Use `->matchError(...)` and `->catchError(...)` for structured domain errors that implement `ResultError`; these
-methods match by class, not by string code.
+methods match by class, not by string code. `matchError(...)` supports flexible callback arity for success,
+unhandled, and matched-error handlers. `catchError(...)` handlers/fallback may return either a recovered value or a
+`Result`.
 
 ```php
 use Maxiviper117\ResultFlow\Result;
@@ -86,9 +88,9 @@ return $result->toResponse();
     - If using arrays, include at least a user-facing `message` key and forward correlation keys from metadata.
     - Avoid mixing many unrelated error shapes in the same chain unless the call site normalizes them.
     - Prefer named classes extending `DataTaggedError` for app/domain failures that need stable API payloads and
-    explicit branch handling.
+        explicit branch handling.
     - Treat `code()` as the stable domain/API identifier for structured errors; matching should be based on the error
-    class.
+        class, with the first matching `matchError(...)` / `catchError(...)` handler winning in array order.
 
     ## Type-safety defaults
 

--- a/resources/boost/skills/result-flow/SKILL.md
+++ b/resources/boost/skills/result-flow/SKILL.md
@@ -23,6 +23,7 @@ Use this skill when the user asks for ResultFlow workflow design, implementation
 6. Use `of(...)` when the callback only returns a value or throws; it wraps the callback return value as the success payload.
 7. Prefer `defer(...)` over `of(...)` when the callback may already return a `Result`, because `defer(...)` preserves that `Result` instead of nesting it.
 8. For batch aggregation, remember `combine(...)` is fail-fast while `combineAll(...)` preserves every failure and returns no success values if any input fails.
+9. When a flow needs named domain failures, prefer subclasses of `DataTaggedError` with class-based `matchError(...)` / `catchError(...)` handling rather than ad-hoc string-based branching.
 
 ## Progressive disclosure rule
 

--- a/resources/boost/skills/result-flow/SKILL.md
+++ b/resources/boost/skills/result-flow/SKILL.md
@@ -23,7 +23,7 @@ Use this skill when the user asks for ResultFlow workflow design, implementation
 6. Use `of(...)` when the callback only returns a value or throws; it wraps the callback return value as the success payload.
 7. Prefer `defer(...)` over `of(...)` when the callback may already return a `Result`, because `defer(...)` preserves that `Result` instead of nesting it.
 8. For batch aggregation, remember `combine(...)` is fail-fast while `combineAll(...)` preserves every failure and returns no success values if any input fails.
-9. When a flow needs named domain failures, prefer subclasses of `DataTaggedError` with class-based `matchError(...)` / `catchError(...)` handling rather than ad-hoc string-based branching.
+9. When a flow needs named domain failures, prefer subclasses of `DataTaggedError` with class-based `matchError(...)` / `catchError(...)` handling rather than ad-hoc string-based branching. Those APIs dispatch by error class, not `code()`, and support flexible callback arity.
 
 ## Progressive disclosure rule
 

--- a/resources/boost/skills/result-flow/references/failure-handling.md
+++ b/resources/boost/skills/result-flow/references/failure-handling.md
@@ -8,6 +8,8 @@ Use when shaping failure behavior and recovery strategy.
 |---|---|
 | Conditional failure mapping/recovery | `otherwise` |
 | Throwable class-based handling | `catchException` |
+| Structured error matching | `matchError` |
+| Structured error recovery | `catchError` |
 | Always recover to success | `recover` |
 | Convert failure to exception at boundary | `throwIfFail` |
 
@@ -15,6 +17,8 @@ Use when shaping failure behavior and recovery strategy.
 
 - Keep one stable failure schema for consumers.
 - Preserve metadata when mapping failures.
+- Use `matchError` and `catchError` for class-based `ResultError` handling.
+- Match structured errors by class, not by string code.
 - Place `throwIfFail` at boundaries, not deep in domain logic.
 
 ## Anti-patterns

--- a/resources/boost/skills/result-flow/references/public-api-whitelist.md
+++ b/resources/boost/skills/result-flow/references/public-api-whitelist.md
@@ -4,7 +4,7 @@ Use this list to ensure generated code sticks to documented public `Result` APIs
 
 ## Static constructors/utilities
 
-- `ok`, `fail`, `failWithValue`, `of`, `defer`, `retry`, `retryDefer`, `retrier`, `bracket`
+- `ok`, `fail`, `failWithValue`, `failTagged`, `of`, `defer`, `retry`, `retryDefer`, `retrier`, `bracket`
 - `combine`, `combineAll`
 - `mapItems`, `mapAll`, `mapCollectErrors`
 
@@ -17,7 +17,7 @@ Use this list to ensure generated code sticks to documented public `Result` APIs
 ## Transform/chaining
 
 - `map`, `mapError`, `ensure`, `then`, `flatMap`, `thenUnsafe`
-- `otherwise`, `catchException`, `recover`
+- `otherwise`, `catchException`, `matchError`, `catchError`, `recover`
 
 ## Completion/unwrapping/output
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Maxiviper117\ResultFlow;
 
 use Maxiviper117\ResultFlow\Laravel\ResultResponse;
+use Maxiviper117\ResultFlow\Support\Errors\Cause;
+use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
 use Maxiviper117\ResultFlow\Support\Operations\Batch;
 use Maxiviper117\ResultFlow\Support\Operations\Pipeline;
 use Maxiviper117\ResultFlow\Support\Operations\Retry;
@@ -16,8 +18,6 @@ use Maxiviper117\ResultFlow\Support\Traits\Taps;
 use Maxiviper117\ResultFlow\Support\Traits\Transform;
 use Maxiviper117\ResultFlow\Support\Traits\Unwrap;
 use Throwable;
-use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
-use Maxiviper117\ResultFlow\Support\Errors\Cause;
 
 /**
  * A minimal Result type with branch-aware chaining.
@@ -37,8 +37,7 @@ final class Result
         private mixed $value,
         private mixed $error,
         private array $meta = [],
-    ) {
-    }
+    ) {}
 
     // =========================================================================
     // Static Constructors
@@ -93,11 +92,7 @@ final class Result
     /**
      * Create a failure result backed by a structured DataTaggedError.
      *
-     * @param string $code
-     * @param string $message
-     * @param mixed $payload
-     * @param array<string,mixed> $meta
-     * @param null|Cause $cause
+     * @param  array<string,mixed>  $meta
      * @return Result<never, DataTaggedError>
      */
     public static function failTagged(string $code, string $message, mixed $payload = null, array $meta = [], ?Cause $cause = null): self
@@ -198,7 +193,7 @@ final class Result
             ->maxAttempts($times)
             ->delay($delay)
             ->exponential($exponential)
-            ->attempt(fn() => self::defer($fn));
+            ->attempt(fn () => self::defer($fn));
 
         return $result;
     }
@@ -247,7 +242,7 @@ final class Result
         $resource = $acquired->value();
 
         /** @var Result<T, E|Throwable> $used */
-        $used = self::defer(fn() => $use($resource));
+        $used = self::defer(fn () => $use($resource));
 
         try {
             $release($resource);
@@ -337,7 +332,7 @@ final class Result
             }
         }
 
-        if (!empty($errors)) {
+        if (! empty($errors)) {
             /** @var Result<array<T>, array<E>> */
             return self::fail($errors, $mergedMeta);
         }
@@ -414,7 +409,7 @@ final class Result
      */
     public function isFail(): bool
     {
-        return !$this->ok;
+        return ! $this->ok;
     }
 
     // =========================================================================
@@ -629,7 +624,7 @@ final class Result
      */
     public function then(callable|object|array $next): self
     {
-        if (!$this->ok) {
+        if (! $this->ok) {
             /** @var Result<U, TFailure> $this @phpstan-ignore varTag.nativeType */
             return $this;
         }
@@ -680,7 +675,7 @@ final class Result
      */
     public function thenUnsafe(callable|object $next): self
     {
-        if (!$this->ok) {
+        if (! $this->ok) {
             /** @var Result<U, TFailure> $this @phpstan-ignore varTag.nativeType */
             return $this;
         }

--- a/src/Result.php
+++ b/src/Result.php
@@ -16,6 +16,8 @@ use Maxiviper117\ResultFlow\Support\Traits\Taps;
 use Maxiviper117\ResultFlow\Support\Traits\Transform;
 use Maxiviper117\ResultFlow\Support\Traits\Unwrap;
 use Throwable;
+use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
+use Maxiviper117\ResultFlow\Support\Errors\Cause;
 
 /**
  * A minimal Result type with branch-aware chaining.
@@ -35,7 +37,8 @@ final class Result
         private mixed $value,
         private mixed $error,
         private array $meta = [],
-    ) {}
+    ) {
+    }
 
     // =========================================================================
     // Static Constructors
@@ -85,6 +88,24 @@ final class Result
     public static function failWithValue(mixed $error, mixed $failedValue, array $meta = []): self
     {
         return self::fail($error, array_merge(['failed_value' => $failedValue], $meta));
+    }
+
+    /**
+     * Create a failure result backed by a structured DataTaggedError.
+     *
+     * @param string $code
+     * @param string $message
+     * @param mixed $payload
+     * @param array<string,mixed> $meta
+     * @param null|Cause $cause
+     * @return Result<never, DataTaggedError>
+     */
+    public static function failTagged(string $code, string $message, mixed $payload = null, array $meta = [], ?Cause $cause = null): self
+    {
+        $err = new DataTaggedError($code, $message, $payload, $cause);
+
+        /** @var Result<never, DataTaggedError> */
+        return self::fail($err, $meta);
     }
 
     /**
@@ -177,7 +198,7 @@ final class Result
             ->maxAttempts($times)
             ->delay($delay)
             ->exponential($exponential)
-            ->attempt(fn () => self::defer($fn));
+            ->attempt(fn() => self::defer($fn));
 
         return $result;
     }
@@ -226,7 +247,7 @@ final class Result
         $resource = $acquired->value();
 
         /** @var Result<T, E|Throwable> $used */
-        $used = self::defer(fn () => $use($resource));
+        $used = self::defer(fn() => $use($resource));
 
         try {
             $release($resource);
@@ -316,7 +337,7 @@ final class Result
             }
         }
 
-        if (! empty($errors)) {
+        if (!empty($errors)) {
             /** @var Result<array<T>, array<E>> */
             return self::fail($errors, $mergedMeta);
         }
@@ -393,7 +414,7 @@ final class Result
      */
     public function isFail(): bool
     {
-        return ! $this->ok;
+        return !$this->ok;
     }
 
     // =========================================================================
@@ -438,7 +459,7 @@ final class Result
      * Convert the Result to a debug-safe array (hides sensitive data).
      *
      * @param  callable(mixed): mixed|null  $sanitizer
-     * @return array{ok: bool, value_type: string|null, error_type: string|null, error_message: mixed, meta: mixed}
+     * @return array{ok: bool, value_type: string|null, error_type: string|null, error_code: string|null, error_message: mixed, meta: mixed}
      */
     public function toDebugArray(?callable $sanitizer = null): array
     {
@@ -608,7 +629,7 @@ final class Result
      */
     public function then(callable|object|array $next): self
     {
-        if (! $this->ok) {
+        if (!$this->ok) {
             /** @var Result<U, TFailure> $this @phpstan-ignore varTag.nativeType */
             return $this;
         }
@@ -659,7 +680,7 @@ final class Result
      */
     public function thenUnsafe(callable|object $next): self
     {
-        if (! $this->ok) {
+        if (!$this->ok) {
             /** @var Result<U, TFailure> $this @phpstan-ignore varTag.nativeType */
             return $this;
         }
@@ -772,6 +793,41 @@ final class Result
     public function catchException(array $handlers, ?callable $fallback = null): self
     {
         return Matcher::catchException($this, $handlers, $fallback);
+    }
+
+    /**
+     * Match on structured ResultError instances by class.
+     *
+     * Use named classes extending DataTaggedError to model distinct domain errors.
+     *
+     * @template TError of \Maxiviper117\ResultFlow\Support\Errors\ResultError
+     * @template R
+     *
+     * @param  array<class-string<TError>, callable(TError, array<string,mixed>): R>  $errorHandlers
+     * @param  callable(TSuccess, array<string,mixed>): R  $onSuccess
+     * @param  callable(TFailure, array<string,mixed>): R  $onUnhandled
+     * @return R
+     */
+    public function matchError(array $errorHandlers, callable $onSuccess, callable $onUnhandled): mixed
+    {
+        return Matcher::matchError($this, $errorHandlers, $onSuccess, $onUnhandled);
+    }
+
+    /**
+     * Handle structured ResultError instances and produce a Result.
+     *
+     * @template TError of \Maxiviper117\ResultFlow\Support\Errors\ResultError
+     *
+     * @param  array<class-string<TError>, callable(TError, array<string,mixed>): (Result<TSuccess, mixed>|TSuccess)>  $handlers
+     * @param  null|callable(TFailure, array<string,mixed>): (Result<TSuccess, mixed>|TSuccess)  $fallback
+     * @return Result<TSuccess, mixed>
+     */
+    public function catchError(array $handlers, ?callable $fallback = null): self
+    {
+        /** @var Result<TSuccess, mixed> $result */
+        $result = Matcher::catchError($this, $handlers, $fallback);
+
+        return $result;
     }
 
     /**

--- a/src/Support/Errors/Cause.php
+++ b/src/Support/Errors/Cause.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maxiviper117\ResultFlow\Support\Errors;
+
+/**
+ * Lightweight nested cause value object for Result errors.
+ */
+final class Cause
+{
+    /**
+     * @param array<string,mixed> $metadata
+     * @param array<int, Cause> $causes
+     */
+    public function __construct(
+        private ?string $code,
+        private string $message,
+        private array $metadata = [],
+        private array $causes = [],
+    ) {
+    }
+
+    public function code(): ?string
+    {
+        return $this->code;
+    }
+
+    public function message(): string
+    {
+        return $this->message;
+    }
+
+    /** @return array<string,mixed> */
+    public function metadata(): array
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * @return array<int, Cause>
+     */
+    public function causes(): array
+    {
+        return $this->causes;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        $out = [
+            'code' => $this->code,
+            'message' => $this->message,
+            'metadata' => $this->metadata,
+        ];
+
+        if (!empty($this->causes)) {
+            $causesArr = [];
+            foreach ($this->causes as $c) {
+                $causesArr[] = $c->toArray();
+            }
+            $out['causes'] = $causesArr;
+        }
+
+        return $out;
+    }
+}

--- a/src/Support/Errors/Cause.php
+++ b/src/Support/Errors/Cause.php
@@ -10,16 +10,15 @@ namespace Maxiviper117\ResultFlow\Support\Errors;
 final class Cause
 {
     /**
-     * @param array<string,mixed> $metadata
-     * @param array<int, Cause> $causes
+     * @param  array<string,mixed>  $metadata
+     * @param  array<int, Cause>  $causes
      */
     public function __construct(
         private ?string $code,
         private string $message,
         private array $metadata = [],
         private array $causes = [],
-    ) {
-    }
+    ) {}
 
     public function code(): ?string
     {
@@ -56,7 +55,7 @@ final class Cause
             'metadata' => $this->metadata,
         ];
 
-        if (!empty($this->causes)) {
+        if (! empty($this->causes)) {
             $causesArr = [];
             foreach ($this->causes as $c) {
                 $causesArr[] = $c->toArray();

--- a/src/Support/Errors/Cause.php
+++ b/src/Support/Errors/Cause.php
@@ -11,10 +11,10 @@ namespace Maxiviper117\ResultFlow\Support\Errors;
 final class Cause
 {
     /**
-     * @param string|null $code - optional domain-level code for the cause (e.g. 'E_DB', 'E_SQL', etc.)
-     * @param string $message - human-readable message describing the cause
-     * @param array<string,mixed> $metadata - optional structured metadata about the cause (e.g. DB table, constraint, etc.)
-     * @param array<int, Cause> $causes - nested causes for multi-level error representation
+     * @param  string|null  $code  - optional domain-level code for the cause (e.g. 'E_DB', 'E_SQL', etc.)
+     * @param  string  $message  - human-readable message describing the cause
+     * @param  array<string,mixed>  $metadata  - optional structured metadata about the cause (e.g. DB table, constraint, etc.)
+     * @param  array<int, Cause>  $causes  - nested causes for multi-level error representation
      */
     public function __construct(
         private ?string $code,

--- a/src/Support/Errors/Cause.php
+++ b/src/Support/Errors/Cause.php
@@ -58,7 +58,7 @@ final class Cause
             'metadata' => $this->metadata,
         ];
 
-        if (! empty($this->causes)) {
+        if ($this->causes !== []) {
             $causesArr = [];
             foreach ($this->causes as $c) {
                 $causesArr[] = $c->toArray();

--- a/src/Support/Errors/Cause.php
+++ b/src/Support/Errors/Cause.php
@@ -6,12 +6,15 @@ namespace Maxiviper117\ResultFlow\Support\Errors;
 
 /**
  * Lightweight nested cause value object for Result errors.
+ * - This is intentionally not an Exception since it's meant to be a simple value object that can be nested and serialized, without the overhead of stack traces or PHP's exception chaining.
  */
 final class Cause
 {
     /**
-     * @param  array<string,mixed>  $metadata
-     * @param  array<int, Cause>  $causes
+     * @param string|null $code - optional domain-level code for the cause (e.g. 'E_DB', 'E_SQL', etc.)
+     * @param string $message - human-readable message describing the cause
+     * @param array<string,mixed> $metadata - optional structured metadata about the cause (e.g. DB table, constraint, etc.)
+     * @param array<int, Cause> $causes - nested causes for multi-level error representation
      */
     public function __construct(
         private ?string $code,

--- a/src/Support/Errors/DataTaggedError.php
+++ b/src/Support/Errors/DataTaggedError.php
@@ -19,7 +19,7 @@ use LogicException;
  *
  * @phpstan-consistent-constructor
  */
-class DataTaggedError extends \RuntimeException implements ResultError, JsonSerializable
+class DataTaggedError extends \RuntimeException implements JsonSerializable, ResultError
 {
     /**
      * Optional subclass constant used by `from(...)` for ergonomic construction.
@@ -27,11 +27,9 @@ class DataTaggedError extends \RuntimeException implements ResultError, JsonSeri
     public const CODE = '';
 
     private mixed $payload;
+
     private ?Cause $causeObj;
 
-    /**
-     * @param mixed $payload
-     */
     public function __construct(string $code, string $message, mixed $payload = null, ?Cause $cause = null)
     {
         parent::__construct($message);
@@ -42,9 +40,6 @@ class DataTaggedError extends \RuntimeException implements ResultError, JsonSeri
 
     /**
      * Construct a named error from the subclass-defined `CODE` constant.
-     *
-     * @param mixed $payload
-     * @return static
      */
     public static function from(string $message, mixed $payload = null, ?Cause $cause = null): static
     {
@@ -108,7 +103,7 @@ class DataTaggedError extends \RuntimeException implements ResultError, JsonSeri
     {
         $code = static::CODE;
 
-        if (!is_string($code) || $code === '') {
+        if (! is_string($code) || $code === '') {
             throw new LogicException(sprintf(
                 '%s must define a non-empty CODE constant or be instantiated with an explicit code.',
                 static::class

--- a/src/Support/Errors/DataTaggedError.php
+++ b/src/Support/Errors/DataTaggedError.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maxiviper117\ResultFlow\Support\Errors;
+
+use JsonSerializable;
+use LogicException;
+
+/**
+ * Base tagged/domain error that is throwable and serializable for APIs.
+ *
+ * This class is intentionally extendable so projects can create domain-specific
+ * error classes that carry a stable code/message/payload shape.
+ *
+ * The domain-level string code is exposed via `code()`. Since PHP exceptions
+ * only support integer native codes, inherited `getCode()` is not used as the
+ * authoritative domain code and may remain `0`.
+ *
+ * @phpstan-consistent-constructor
+ */
+class DataTaggedError extends \RuntimeException implements ResultError, JsonSerializable
+{
+    /**
+     * Optional subclass constant used by `from(...)` for ergonomic construction.
+     */
+    public const CODE = '';
+
+    private mixed $payload;
+    private ?Cause $causeObj;
+
+    /**
+     * @param mixed $payload
+     */
+    public function __construct(string $code, string $message, mixed $payload = null, ?Cause $cause = null)
+    {
+        parent::__construct($message);
+        $this->payload = $payload;
+        $this->causeObj = $cause;
+        $this->reflectionCode = $code;
+    }
+
+    /**
+     * Construct a named error from the subclass-defined `CODE` constant.
+     *
+     * @param mixed $payload
+     * @return static
+     */
+    public static function from(string $message, mixed $payload = null, ?Cause $cause = null): static
+    {
+        return new static(static::definedCode(), $message, $payload, $cause);
+    }
+
+    private string $reflectionCode = '';
+
+    public function code(): string
+    {
+        return $this->reflectionCode;
+    }
+
+    public function message(): string
+    {
+        return $this->getMessage();
+    }
+
+    public function payload(): mixed
+    {
+        return $this->payload;
+    }
+
+    public function cause(): ?Cause
+    {
+        return $this->causeObj;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        $out = [
+            'code' => $this->code(),
+            'message' => $this->message(),
+        ];
+
+        if ($this->payload !== null) {
+            $out['payload'] = $this->payload;
+        }
+
+        if ($this->causeObj !== null) {
+            $out['cause'] = $this->causeObj->toArray();
+        }
+
+        return $out;
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+
+    public function __toString(): string
+    {
+        return $this->message();
+    }
+
+    protected static function definedCode(): string
+    {
+        $code = static::CODE;
+
+        if (!is_string($code) || $code === '') {
+            throw new LogicException(sprintf(
+                '%s must define a non-empty CODE constant or be instantiated with an explicit code.',
+                static::class
+            ));
+        }
+
+        return $code;
+    }
+}

--- a/src/Support/Errors/DataTaggedError.php
+++ b/src/Support/Errors/DataTaggedError.php
@@ -35,7 +35,7 @@ class DataTaggedError extends \RuntimeException implements JsonSerializable, Res
         parent::__construct($message);
         $this->payload = $payload;
         $this->causeObj = $cause;
-        $this->reflectionCode = $code;
+        $this->domainCode = $code;
     }
 
     /**
@@ -46,11 +46,11 @@ class DataTaggedError extends \RuntimeException implements JsonSerializable, Res
         return new static(static::definedCode(), $message, $payload, $cause);
     }
 
-    private string $reflectionCode = '';
+    private string $domainCode = '';
 
     public function code(): string
     {
-        return $this->reflectionCode;
+        return $this->domainCode;
     }
 
     public function message(): string
@@ -82,7 +82,7 @@ class DataTaggedError extends \RuntimeException implements JsonSerializable, Res
             $out['payload'] = $this->payload;
         }
 
-        if ($this->causeObj !== null) {
+        if ($this->causeObj instanceof Cause) {
             $out['cause'] = $this->causeObj->toArray();
         }
 

--- a/src/Support/Errors/ResultError.php
+++ b/src/Support/Errors/ResultError.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maxiviper117\ResultFlow\Support\Errors;
+
+/**
+ * Interface representing a structured, serializable error payload for Results.
+ */
+interface ResultError
+{
+    public function code(): string;
+
+    public function message(): string;
+
+    /**
+     * Optional payload useful for HTTP APIs / debugging.
+     *
+     * @return mixed
+     */
+    public function payload(): mixed;
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array;
+
+    /**
+     * Optional cause chain attached to this error.
+     */
+    public function cause(): ?Cause;
+}

--- a/src/Support/Errors/ResultError.php
+++ b/src/Support/Errors/ResultError.php
@@ -15,8 +15,6 @@ interface ResultError
 
     /**
      * Optional payload useful for HTTP APIs / debugging.
-     *
-     * @return mixed
      */
     public function payload(): mixed;
 

--- a/src/Support/Output/Debug.php
+++ b/src/Support/Output/Debug.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Maxiviper117\ResultFlow\Support\Output;
 
 use Maxiviper117\ResultFlow\Result;
+use Maxiviper117\ResultFlow\Support\Errors\ResultError;
 use Throwable;
 
 /**
@@ -20,7 +21,7 @@ final class Debug
      *
      * @param  Result<TSuccess, TFailure>  $result
      * @param  callable(mixed): mixed|null  $sanitizer
-     * @return array{ok: bool, value_type: string|null, error_type: string|null, error_message: mixed, meta: mixed}
+     * @return array{ok: bool, value_type: string|null, error_type: string|null, error_code: string|null, error_message: mixed, meta: mixed}
      */
     public static function toDebugArray(Result $result, ?callable $sanitizer = null): array
     {
@@ -28,13 +29,26 @@ final class Debug
         $ok = $result->isOk();
         $error = $result->error();
 
+        $errorCode = null;
+        $errorMessage = null;
+
+        if (!$ok) {
+            if ($error instanceof ResultError) {
+                $errorCode = $error->code();
+                $errorMessage = $sanitizer($error->message());
+            } elseif ($error instanceof Throwable) {
+                $errorMessage = $sanitizer($error->getMessage());
+            } elseif (is_string($error)) {
+                $errorMessage = $sanitizer($error);
+            }
+        }
+
         return [
             'ok' => $ok,
             'value_type' => $ok ? get_debug_type($result->value()) : null,
-            'error_type' => ! $ok ? get_debug_type($error) : null,
-            'error_message' => ! $ok && $error instanceof Throwable
-                ? $sanitizer($error->getMessage())
-                : (! $ok && is_string($error) ? $sanitizer($error) : null),
+            'error_type' => !$ok ? get_debug_type($error) : null,
+            'error_code' => $errorCode,
+            'error_message' => $errorMessage,
             'meta' => $sanitizer($result->meta()),
         ];
     }
@@ -65,7 +79,7 @@ final class Debug
         $sensitiveKeys = is_array($rawSensitiveKeys) ? $rawSensitiveKeys : $defaultSensitiveKeys;
         $sensitiveKeys = array_values(array_filter(
             $sensitiveKeys,
-            static fn ($value): bool => is_string($value) && $value !== ''
+            static fn($value): bool => is_string($value) && $value !== ''
         ));
         /** @var array<int, string> $sensitiveKeys */
         $max = is_int($debugConfig['max_string_length'] ?? null)
@@ -73,7 +87,7 @@ final class Debug
             : 200;
         $truncateStrings = ($debugConfig['truncate_strings'] ?? true) === true;
 
-        if (! $enabled) {
+        if (!$enabled) {
             return $value;
         }
 
@@ -140,7 +154,7 @@ final class Debug
 
         $cacheKey = sha1(serialize($patterns));
 
-        if (! isset($cache[$cacheKey])) {
+        if (!isset($cache[$cacheKey])) {
             /** @var array<int, string> $regexes */
             $regexes = [];
             foreach ($patterns as $p) {

--- a/src/Support/Output/Debug.php
+++ b/src/Support/Output/Debug.php
@@ -32,7 +32,7 @@ final class Debug
         $errorCode = null;
         $errorMessage = null;
 
-        if (!$ok) {
+        if (! $ok) {
             if ($error instanceof ResultError) {
                 $errorCode = $error->code();
                 $errorMessage = $sanitizer($error->message());
@@ -46,7 +46,7 @@ final class Debug
         return [
             'ok' => $ok,
             'value_type' => $ok ? get_debug_type($result->value()) : null,
-            'error_type' => !$ok ? get_debug_type($error) : null,
+            'error_type' => ! $ok ? get_debug_type($error) : null,
             'error_code' => $errorCode,
             'error_message' => $errorMessage,
             'meta' => $sanitizer($result->meta()),
@@ -79,7 +79,7 @@ final class Debug
         $sensitiveKeys = is_array($rawSensitiveKeys) ? $rawSensitiveKeys : $defaultSensitiveKeys;
         $sensitiveKeys = array_values(array_filter(
             $sensitiveKeys,
-            static fn($value): bool => is_string($value) && $value !== ''
+            static fn ($value): bool => is_string($value) && $value !== ''
         ));
         /** @var array<int, string> $sensitiveKeys */
         $max = is_int($debugConfig['max_string_length'] ?? null)
@@ -87,7 +87,7 @@ final class Debug
             : 200;
         $truncateStrings = ($debugConfig['truncate_strings'] ?? true) === true;
 
-        if (!$enabled) {
+        if (! $enabled) {
             return $value;
         }
 
@@ -154,7 +154,7 @@ final class Debug
 
         $cacheKey = sha1(serialize($patterns));
 
-        if (!isset($cache[$cacheKey])) {
+        if (! isset($cache[$cacheKey])) {
             /** @var array<int, string> $regexes */
             $regexes = [];
             foreach ($patterns as $p) {

--- a/src/Support/Output/Serialization.php
+++ b/src/Support/Output/Serialization.php
@@ -123,7 +123,7 @@ final class Serialization
             return 'item';
         }
 
-        if (!preg_match('/^[A-Za-z_]/', $normalized) || str_starts_with(strtolower($normalized), 'xml')) {
+        if (! preg_match('/^[A-Za-z_]/', $normalized) || str_starts_with(strtolower($normalized), 'xml')) {
             $normalized = 'item_'.$normalized;
         }
 

--- a/src/Support/Output/Serialization.php
+++ b/src/Support/Output/Serialization.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Maxiviper117\ResultFlow\Support\Output;
 
 use Maxiviper117\ResultFlow\Result;
+use Maxiviper117\ResultFlow\Support\Errors\ResultError;
 
 /**
  * Helpers for serializing Results to arrays and text formats.
@@ -22,10 +23,18 @@ final class Serialization
      */
     public static function toArray(Result $result): array
     {
+        $error = $result->error();
+
+        if ($error instanceof ResultError) {
+            $errorOut = $error->toArray();
+        } else {
+            $errorOut = $error;
+        }
+
         return [
             'ok' => $result->isOk(),
             'value' => $result->value(),
-            'error' => $result->error(),
+            'error' => $errorOut,
             'meta' => $result->meta(),
         ];
     }
@@ -114,7 +123,7 @@ final class Serialization
             return 'item';
         }
 
-        if (! preg_match('/^[A-Za-z_]/', $normalized) || str_starts_with(strtolower($normalized), 'xml')) {
+        if (!preg_match('/^[A-Za-z_]/', $normalized) || str_starts_with(strtolower($normalized), 'xml')) {
             $normalized = 'item_'.$normalized;
         }
 

--- a/src/Support/Traits/Matcher.php
+++ b/src/Support/Traits/Matcher.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Maxiviper117\ResultFlow\Support\Traits;
 
 use Maxiviper117\ResultFlow\Result;
-use Throwable;
 use Maxiviper117\ResultFlow\Support\Errors\ResultError;
+use Throwable;
 
 /**
  * Pattern-matching helpers for Result values and exceptions.
@@ -142,10 +142,10 @@ final class Matcher
      * @template TError of ResultError
      * @template R
      *
-     * @param Result<TSuccess, TFailure> $result
-     * @param array<class-string<TError>, callable(TError, array<string,mixed>): R> $errorHandlers
-     * @param callable(TSuccess, array<string,mixed>): R $onSuccess
-     * @param callable(TFailure, array<string,mixed>): R $onUnhandled
+     * @param  Result<TSuccess, TFailure>  $result
+     * @param  array<class-string<TError>, callable(TError, array<string,mixed>): R>  $errorHandlers
+     * @param  callable(TSuccess, array<string,mixed>): R  $onSuccess
+     * @param  callable(TFailure, array<string,mixed>): R  $onUnhandled
      * @return R
      */
     public static function matchError(Result $result, array $errorHandlers, callable $onSuccess, callable $onUnhandled): mixed
@@ -180,9 +180,9 @@ final class Matcher
      * @template TError of ResultError
      * @template UFailure
      *
-     * @param Result<TSuccess, TFailure> $result
-     * @param array<class-string<TError>, callable(TError, array<string,mixed>): (Result<TSuccess, UFailure>|TSuccess)> $handlers
-     * @param null|callable(TFailure, array<string,mixed>): (Result<TSuccess, UFailure>|TSuccess) $fallback
+     * @param  Result<TSuccess, TFailure>  $result
+     * @param  array<class-string<TError>, callable(TError, array<string,mixed>): (Result<TSuccess, UFailure>|TSuccess)>  $handlers
+     * @param  null|callable(TFailure, array<string,mixed>): (Result<TSuccess, UFailure>|TSuccess)  $fallback
      * @return Result<TSuccess, UFailure>
      */
     public static function catchError(Result $result, array $handlers, ?callable $fallback = null): Result

--- a/src/Support/Traits/Matcher.php
+++ b/src/Support/Traits/Matcher.php
@@ -6,6 +6,7 @@ namespace Maxiviper117\ResultFlow\Support\Traits;
 
 use Maxiviper117\ResultFlow\Result;
 use Throwable;
+use Maxiviper117\ResultFlow\Support\Errors\ResultError;
 
 /**
  * Pattern-matching helpers for Result values and exceptions.
@@ -100,6 +101,103 @@ final class Matcher
         if ($error instanceof Throwable) {
             foreach ($handlers as $class => $handler) {
                 if ($error instanceof $class) {
+                    $out = $handler($error, $result->meta());
+
+                    if ($out instanceof Result) {
+                        /** @var Result<TSuccess, UFailure> $out */
+                        return $out;
+                    }
+
+                    /** @var Result<TSuccess, UFailure> */
+                    return Result::ok($out, $result->meta());
+                }
+            }
+        }
+
+        if ($fallback !== null) {
+            $out = $fallback($error, $result->meta());
+
+            if ($out instanceof Result) {
+                /** @var Result<TSuccess, UFailure> $out */
+                return $out;
+            }
+
+            /** @var Result<TSuccess, UFailure> */
+            return Result::ok($out, $result->meta());
+        }
+
+        /** @var Result<TSuccess, UFailure> $result @phpstan-ignore varTag.nativeType */
+        return $result;
+    }
+
+    /**
+     * Match on structured ResultError instances by class name.
+     *
+     * Each named class extending DataTaggedError is treated as a distinct error.
+     * Stable string codes remain useful for serialization and external boundaries,
+     * but matching is class-based only.
+     *
+     * @template TSuccess
+     * @template TFailure
+     * @template TError of ResultError
+     * @template R
+     *
+     * @param Result<TSuccess, TFailure> $result
+     * @param array<class-string<TError>, callable(TError, array<string,mixed>): R> $errorHandlers
+     * @param callable(TSuccess, array<string,mixed>): R $onSuccess
+     * @param callable(TFailure, array<string,mixed>): R $onUnhandled
+     * @return R
+     */
+    public static function matchError(Result $result, array $errorHandlers, callable $onSuccess, callable $onUnhandled): mixed
+    {
+        if ($result->isOk()) {
+            /** @var TSuccess $value */
+            $value = $result->value();
+
+            return $onSuccess($value, $result->meta());
+        }
+
+        /** @var TFailure $error */
+        $error = $result->error();
+
+        if ($error instanceof ResultError) {
+            foreach ($errorHandlers as $key => $handler) {
+                if (class_exists($key) && $error instanceof $key) {
+                    return $handler($error, $result->meta());
+                }
+            }
+        }
+
+        return $onUnhandled($error, $result->meta());
+    }
+
+    /**
+     * Handle structured ResultError instances and produce a Result.
+     * Similar to catchException but matches by class name only.
+     *
+     * @template TSuccess
+     * @template TFailure
+     * @template TError of ResultError
+     * @template UFailure
+     *
+     * @param Result<TSuccess, TFailure> $result
+     * @param array<class-string<TError>, callable(TError, array<string,mixed>): (Result<TSuccess, UFailure>|TSuccess)> $handlers
+     * @param null|callable(TFailure, array<string,mixed>): (Result<TSuccess, UFailure>|TSuccess) $fallback
+     * @return Result<TSuccess, UFailure>
+     */
+    public static function catchError(Result $result, array $handlers, ?callable $fallback = null): Result
+    {
+        if ($result->isOk()) {
+            /** @var Result<TSuccess, UFailure> $result */
+            return $result;
+        }
+
+        /** @var TFailure $error */
+        $error = $result->error();
+
+        if ($error instanceof ResultError) {
+            foreach ($handlers as $key => $handler) {
+                if (class_exists($key) && $error instanceof $key) {
                     $out = $handler($error, $result->meta());
 
                     if ($out instanceof Result) {

--- a/src/Support/Traits/Matcher.php
+++ b/src/Support/Traits/Matcher.php
@@ -131,64 +131,98 @@ final class Matcher
     }
 
     /**
-     * Match on structured ResultError instances by class name.
+     * Match a Result failure against class-based error handlers.
      *
-     * Each named class extending DataTaggedError is treated as a distinct error.
-     * Stable string codes remain useful for serialization and external boundaries,
-     * but matching is class-based only.
+     * Handlers are checked in array iteration order. The first matching handler
+     * whose class-string key matches the failure via instanceof is invoked.
+     *
+     * If the Result is successful, $onSuccess is invoked.
+     * If the failure is not a ResultError, or no handler matches, $onUnhandled is invoked.
+     *
+     * Error handlers may accept either:
+     * - the matched error only
+     * - the matched error and metadata
+     *
+     * Success and unhandled callbacks may accept either:
+     * - no arguments
+     * - the value/error only
+     * - the value/error and metadata
      *
      * @template TSuccess
      * @template TFailure
      * @template TError of ResultError
      * @template R
      *
-     * @param  Result<TSuccess, TFailure>  $result
-     * @param  array<class-string<TError>, callable(TError, array<string,mixed>): R>  $errorHandlers
-     * @param  callable(TSuccess, array<string,mixed>): R  $onSuccess
-     * @param  callable(TFailure, array<string,mixed>): R  $onUnhandled
+     * @param Result<TSuccess, TFailure> $result
+     * @param array<class-string<TError>, callable> $errorHandlers
+     * @param callable(): R|callable(TSuccess): R|callable(TSuccess, array<string, mixed>): R $onSuccess
+     * @param callable(): R|callable(TFailure): R|callable(TFailure, array<string, mixed>): R $onUnhandled
      * @return R
      */
-    public static function matchError(Result $result, array $errorHandlers, callable $onSuccess, callable $onUnhandled): mixed
-    {
+    public static function matchError(
+        Result $result,
+        array $errorHandlers,
+        callable $onSuccess,
+        callable $onUnhandled,
+    ): mixed {
+        $meta = $result->meta();
+
         if ($result->isOk()) {
             /** @var TSuccess $value */
             $value = $result->value();
 
-            return $onSuccess($value, $result->meta());
+            return self::invokeMatchCallback($onSuccess, $value, $meta);
         }
 
         /** @var TFailure $error */
         $error = $result->error();
 
         if ($error instanceof ResultError) {
-            foreach ($errorHandlers as $key => $handler) {
-                if (class_exists($key) && $error instanceof $key) {
-                    return $handler($error, $result->meta());
+            foreach ($errorHandlers as $errorClass => $handler) {
+                if ($error instanceof $errorClass) {
+                    return self::invokeMatchCallback($handler, $error, $meta);
                 }
             }
         }
 
-        return $onUnhandled($error, $result->meta());
+        return self::invokeMatchCallback($onUnhandled, $error, $meta);
     }
 
     /**
-     * Handle structured ResultError instances and produce a Result.
-     * Similar to catchException but matches by class name only.
+     * Handle structured ResultError instances and recover to a Result.
+     *
+     * Similar to catchException, but matches failures by error class name only.
+     *
+     * Handlers are checked in array iteration order. The first matching handler
+     * whose class-string key matches the failure via instanceof is invoked.
+     *
+     * Handler and fallback callbacks may accept either:
+     * - no arguments
+     * - the error only
+     * - the error and metadata
+     *
+     * Each callback may return either:
+     * - a recovered success value
+     * - a Result
+     *
+     * If no handler matches and no fallback is provided, the original Result is returned.
      *
      * @template TSuccess
      * @template TFailure
      * @template TError of ResultError
      * @template UFailure
      *
-     * @param  Result<TSuccess, TFailure>  $result
-     * @param  array<class-string<TError>, callable(TError, array<string,mixed>): (Result<TSuccess, UFailure>|TSuccess)>  $handlers
-     * @param  null|callable(TFailure, array<string,mixed>): (Result<TSuccess, UFailure>|TSuccess)  $fallback
-     * @return Result<TSuccess, UFailure>
+     * @param Result<TSuccess, TFailure> $result
+     * @param array<class-string<TError>, callable> $handlers
+     * @param (callable(): (Result<TSuccess, UFailure>|TSuccess)|callable(TFailure): (Result<TSuccess, UFailure>|TSuccess)|callable(TFailure, array<string, mixed>): (Result<TSuccess, UFailure>|TSuccess))|null $fallback
+     * @return Result<TSuccess, TFailure|UFailure>
      */
     public static function catchError(Result $result, array $handlers, ?callable $fallback = null): Result
     {
+        $meta = $result->meta();
+
         if ($result->isOk()) {
-            /** @var Result<TSuccess, UFailure> $result */
+            /** @var Result<TSuccess, TFailure|UFailure> $result */
             return $result;
         }
 
@@ -196,34 +230,112 @@ final class Matcher
         $error = $result->error();
 
         if ($error instanceof ResultError) {
-            foreach ($handlers as $key => $handler) {
-                if (class_exists($key) && $error instanceof $key) {
-                    $out = $handler($error, $result->meta());
+            foreach ($handlers as $errorClass => $handler) {
+                if ($error instanceof $errorClass) {
+                    $out = self::invokeCatchCallback($handler, $error, $meta);
 
                     if ($out instanceof Result) {
-                        /** @var Result<TSuccess, UFailure> $out */
+                        /** @var Result<TSuccess, TFailure|UFailure> $out */
                         return $out;
                     }
 
-                    /** @var Result<TSuccess, UFailure> */
-                    return Result::ok($out, $result->meta());
+                    /** @var Result<TSuccess, TFailure|UFailure> */
+                    return Result::ok($out, $meta);
                 }
             }
         }
 
         if ($fallback !== null) {
-            $out = $fallback($error, $result->meta());
+            $out = self::invokeCatchCallback($fallback, $error, $meta);
 
             if ($out instanceof Result) {
-                /** @var Result<TSuccess, UFailure> $out */
+                /** @var Result<TSuccess, TFailure|UFailure> $out */
                 return $out;
             }
 
-            /** @var Result<TSuccess, UFailure> */
-            return Result::ok($out, $result->meta());
+            /** @var Result<TSuccess, TFailure|UFailure> */
+            return Result::ok($out, $meta);
         }
 
-        /** @var Result<TSuccess, UFailure> $result @phpstan-ignore varTag.nativeType */
-        return $result;
+        /** @var Result<TSuccess, TFailure|UFailure> */
+        return Result::fail($error, $meta);
+    }
+
+    /**
+     * @template TValue
+     *
+     * @param callable $callback
+     * @param TValue $value
+     * @param array<string, mixed> $meta
+     * @return mixed
+     */
+    private static function invokeMatchCallback(callable $callback, mixed $value, array $meta): mixed
+    {
+        $reflection = self::reflectCallable($callback);
+        $parameterCount = $reflection->getNumberOfParameters();
+
+        return match (true) {
+            $parameterCount <= 0 => $callback(),
+            $parameterCount === 1 => $callback($value),
+            default => $callback($value, $meta),
+        };
+    }
+
+    /**
+     * @param callable $callback
+     */
+    private static function reflectCallable(callable $callback): \ReflectionFunctionAbstract
+    {
+        if ($callback instanceof \Closure) {
+            return new \ReflectionFunction($callback);
+        }
+
+        if (is_array($callback)) {
+            $target = $callback[0] ?? null;
+            $method = $callback[1] ?? null;
+
+            if ((is_object($target) || is_string($target)) && is_string($method)) {
+                return new \ReflectionMethod($target, $method);
+            }
+
+            throw new \InvalidArgumentException('Invalid array callable.');
+        }
+
+        if (is_string($callback) && str_contains($callback, '::')) {
+            return new \ReflectionMethod($callback);
+        }
+
+        if (is_object($callback)) {
+            return new \ReflectionMethod($callback, '__invoke');
+        }
+
+        return new \ReflectionFunction(\Closure::fromCallable($callback));
+    }
+
+    /**
+     * Invoke a flexible catch callback.
+     *
+     * Supported callback forms:
+     * - fn(): mixed
+     * - fn(TValue): mixed
+     * - fn(TValue, array<string, mixed>): mixed
+     *
+     * @template TValue
+     *
+     * @param callable $callback
+     * @param TValue $value
+     * @param array<string, mixed> $meta
+     * @return mixed
+     */
+    private static function invokeCatchCallback(callable $callback, mixed $value, array $meta): mixed
+    {
+        $reflection = self::reflectCallable($callback);
+        $parameterCount = $reflection->getNumberOfParameters();
+
+        return match (true) {
+            $parameterCount <= 0 => $callback(),
+            $parameterCount === 1 => $callback($value),
+            default => $callback($value, $meta),
+        };
     }
 }

--- a/src/Support/Traits/Matcher.php
+++ b/src/Support/Traits/Matcher.php
@@ -257,8 +257,8 @@ final class Matcher
             return Result::ok($out, $meta);
         }
 
-        /** @var Result<TSuccess, TFailure|UFailure> */
-        return Result::fail($error, $meta);
+        /** @var Result<TSuccess, TFailure|UFailure> $result @phpstan-ignore varTag.nativeType */
+        return $result;
     }
 
     /**

--- a/src/Support/Traits/Matcher.php
+++ b/src/Support/Traits/Matcher.php
@@ -153,10 +153,10 @@ final class Matcher
      * @template TError of ResultError
      * @template R
      *
-     * @param Result<TSuccess, TFailure> $result
-     * @param array<class-string<TError>, callable> $errorHandlers
-     * @param callable(): R|callable(TSuccess): R|callable(TSuccess, array<string, mixed>): R $onSuccess
-     * @param callable(): R|callable(TFailure): R|callable(TFailure, array<string, mixed>): R $onUnhandled
+     * @param  Result<TSuccess, TFailure>  $result
+     * @param  array<class-string<TError>, callable>  $errorHandlers
+     * @param  callable(): R|callable(TSuccess): R|callable(TSuccess, array<string, mixed>): R  $onSuccess
+     * @param  callable(): R|callable(TFailure): R|callable(TFailure, array<string, mixed>): R  $onUnhandled
      * @return R
      */
     public static function matchError(
@@ -212,9 +212,9 @@ final class Matcher
      * @template TError of ResultError
      * @template UFailure
      *
-     * @param Result<TSuccess, TFailure> $result
-     * @param array<class-string<TError>, callable> $handlers
-     * @param (callable(): (Result<TSuccess, UFailure>|TSuccess)|callable(TFailure): (Result<TSuccess, UFailure>|TSuccess)|callable(TFailure, array<string, mixed>): (Result<TSuccess, UFailure>|TSuccess))|null $fallback
+     * @param  Result<TSuccess, TFailure>  $result
+     * @param  array<class-string<TError>, callable>  $handlers
+     * @param  (callable(): (Result<TSuccess, UFailure>|TSuccess)|callable(TFailure): (Result<TSuccess, UFailure>|TSuccess)|callable(TFailure, array<string, mixed>): (Result<TSuccess, UFailure>|TSuccess))|null  $fallback
      * @return Result<TSuccess, TFailure|UFailure>
      */
     public static function catchError(Result $result, array $handlers, ?callable $fallback = null): Result
@@ -264,10 +264,8 @@ final class Matcher
     /**
      * @template TValue
      *
-     * @param callable $callback
-     * @param TValue $value
-     * @param array<string, mixed> $meta
-     * @return mixed
+     * @param  TValue  $value
+     * @param  array<string, mixed>  $meta
      */
     private static function invokeMatchCallback(callable $callback, mixed $value, array $meta): mixed
     {
@@ -281,9 +279,6 @@ final class Matcher
         };
     }
 
-    /**
-     * @param callable $callback
-     */
     private static function reflectCallable(callable $callback): \ReflectionFunctionAbstract
     {
         if ($callback instanceof \Closure) {
@@ -322,10 +317,8 @@ final class Matcher
      *
      * @template TValue
      *
-     * @param callable $callback
-     * @param TValue $value
-     * @param array<string, mixed> $meta
-     * @return mixed
+     * @param  TValue  $value
+     * @param  array<string, mixed>  $meta
      */
     private static function invokeCatchCallback(callable $callback, mixed $value, array $meta): mixed
     {

--- a/tests/ResultErrorCauseTest.php
+++ b/tests/ResultErrorCauseTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use Maxiviper117\ResultFlow\Result;
+use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
+use Maxiviper117\ResultFlow\Support\Errors\Cause;
+
+class ReviewTestError extends DataTaggedError
+{
+    public const CODE = 'E_REVIEW';
+}
+
+class AnotherReviewTestError extends DataTaggedError
+{
+    public const CODE = 'E_REVIEW_ALT';
+}
+
+class MissingCodeReviewError extends DataTaggedError
+{
+}
+
+describe('DataTaggedError and Cause integration', function () {
+    it('serializes DataTaggedError with nested Cause to array and JSON', function () {
+        $child = new Cause('E_DB', 'DB failed', ['query' => 'INSERT']);
+        $cause = new Cause('E_PERSIST', 'Persist failed', [], [$child]);
+
+        $err = new DataTaggedError('E_NOT_FOUND', 'Not found', ['id' => 42], $cause);
+        $result = Result::fail($err);
+
+        $arr = $result->toArray();
+
+        expect($arr['ok'])->toBeFalse();
+        expect($arr['error'])->toBe($err->toArray());
+
+        $json = $result->toJson();
+        $decoded = json_decode($json, true);
+
+        expect($decoded['error']['code'])->toBe('E_NOT_FOUND');
+        expect($decoded['error']['cause']['code'])->toBe('E_PERSIST');
+        expect($decoded['error']['cause']['causes'][0]['code'])->toBe('E_DB');
+    });
+
+    it('provides debug fields including error_code and message', function () {
+        $err = new DataTaggedError('E_X', 'Something broke', null);
+        $result = Result::fail($err);
+
+        $debug = $result->toDebugArray();
+
+        expect($debug['error_code'])->toBe('E_X');
+        expect($debug['error_message'])->toBe('Something broke');
+    });
+
+    it('can match by error class using matchError', function () {
+        $err = new ReviewTestError('E_HANDLE', 'Handle me', null);
+        $result = Result::fail($err);
+
+        $out = $result->matchError([
+            ReviewTestError::class => function ($e) {
+                return 'handled:'.$e->code();
+            }
+        ], fn($v) => 'ok', fn($e) => 'unhandled');
+
+        expect($out)->toBe('handled:E_HANDLE');
+    });
+
+    it('throwIfFail throws the DataTaggedError (it is Throwable)', function () {
+        $err = new DataTaggedError('E_THROW', 'Throw me');
+        $result = Result::fail($err);
+
+        expect(function () use ($result) {
+            $result->throwIfFail();
+        })->toThrow(DataTaggedError::class);
+    });
+
+    it('can recover by class using catchError', function () {
+        $result = Result::fail(ReviewTestError::from('Recover me'));
+
+        $recovered = $result->catchError([
+            ReviewTestError::class => fn(ReviewTestError $e) => 'recovered:'.$e->code(),
+        ]);
+
+        expect($recovered->isOk())->toBeTrue();
+        expect($recovered->value())->toBe('recovered:E_REVIEW');
+    });
+
+    it('returns the original failed result when no class handler matches and no fallback is provided', function () {
+        $result = Result::fail(AnotherReviewTestError::from('No handler'));
+
+        $unchanged = $result->catchError([
+            ReviewTestError::class => fn(ReviewTestError $e) => 'wrong',
+        ]);
+
+        expect($unchanged->isFail())->toBeTrue();
+        expect($unchanged->error())->toBeInstanceOf(AnotherReviewTestError::class);
+    });
+
+    it('uses fallback when failure is not a ResultError', function () {
+        $result = Result::fail('legacy-error');
+
+        $handled = $result->catchError([
+            ReviewTestError::class => fn(ReviewTestError $e) => 'wrong',
+        ], fn($error) => 'fallback:'.$error);
+
+        expect($handled->isOk())->toBeTrue();
+        expect($handled->value())->toBe('fallback:legacy-error');
+    });
+
+    it('preserves failure when catchError handler returns a failed Result', function () {
+        $result = Result::fail(ReviewTestError::from('Refail'));
+
+        $handled = $result->catchError([
+            ReviewTestError::class => fn(ReviewTestError $e) => Result::fail(AnotherReviewTestError::from('Still failing')),
+        ]);
+
+        expect($handled->isFail())->toBeTrue();
+        expect($handled->error())->toBeInstanceOf(AnotherReviewTestError::class);
+    });
+
+    it('can create named errors from subclass CODE constants', function () {
+        $error = ReviewTestError::from('Created from constant', ['x' => 1]);
+
+        expect($error)->toBeInstanceOf(ReviewTestError::class);
+        expect($error->code())->toBe('E_REVIEW');
+        expect($error->payload())->toBe(['x' => 1]);
+    });
+
+    it('throws when named constructor is used without a subclass CODE constant', function () {
+        expect(fn() => MissingCodeReviewError::from('Missing code'))->toThrow(LogicException::class);
+    });
+});

--- a/tests/ResultErrorCauseTest.php
+++ b/tests/ResultErrorCauseTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use Maxiviper117\ResultFlow\Result;
-use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
 use Maxiviper117\ResultFlow\Support\Errors\Cause;
+use Maxiviper117\ResultFlow\Support\Errors\DataTaggedError;
 
 class ReviewTestError extends DataTaggedError
 {
@@ -14,9 +14,7 @@ class AnotherReviewTestError extends DataTaggedError
     public const CODE = 'E_REVIEW_ALT';
 }
 
-class MissingCodeReviewError extends DataTaggedError
-{
-}
+class MissingCodeReviewError extends DataTaggedError {}
 
 describe('DataTaggedError and Cause integration', function () {
     it('serializes DataTaggedError with nested Cause to array and JSON', function () {
@@ -56,8 +54,8 @@ describe('DataTaggedError and Cause integration', function () {
         $out = $result->matchError([
             ReviewTestError::class => function ($e) {
                 return 'handled:'.$e->code();
-            }
-        ], fn($v) => 'ok', fn($e) => 'unhandled');
+            },
+        ], fn ($v) => 'ok', fn ($e) => 'unhandled');
 
         expect($out)->toBe('handled:E_HANDLE');
     });
@@ -75,7 +73,7 @@ describe('DataTaggedError and Cause integration', function () {
         $result = Result::fail(ReviewTestError::from('Recover me'));
 
         $recovered = $result->catchError([
-            ReviewTestError::class => fn(ReviewTestError $e) => 'recovered:'.$e->code(),
+            ReviewTestError::class => fn (ReviewTestError $e) => 'recovered:'.$e->code(),
         ]);
 
         expect($recovered->isOk())->toBeTrue();
@@ -86,7 +84,7 @@ describe('DataTaggedError and Cause integration', function () {
         $result = Result::fail(AnotherReviewTestError::from('No handler'));
 
         $unchanged = $result->catchError([
-            ReviewTestError::class => fn(ReviewTestError $e) => 'wrong',
+            ReviewTestError::class => fn (ReviewTestError $e) => 'wrong',
         ]);
 
         expect($unchanged->isFail())->toBeTrue();
@@ -97,8 +95,8 @@ describe('DataTaggedError and Cause integration', function () {
         $result = Result::fail('legacy-error');
 
         $handled = $result->catchError([
-            ReviewTestError::class => fn(ReviewTestError $e) => 'wrong',
-        ], fn($error) => 'fallback:'.$error);
+            ReviewTestError::class => fn (ReviewTestError $e) => 'wrong',
+        ], fn ($error) => 'fallback:'.$error);
 
         expect($handled->isOk())->toBeTrue();
         expect($handled->value())->toBe('fallback:legacy-error');
@@ -108,7 +106,7 @@ describe('DataTaggedError and Cause integration', function () {
         $result = Result::fail(ReviewTestError::from('Refail'));
 
         $handled = $result->catchError([
-            ReviewTestError::class => fn(ReviewTestError $e) => Result::fail(AnotherReviewTestError::from('Still failing')),
+            ReviewTestError::class => fn (ReviewTestError $e) => Result::fail(AnotherReviewTestError::from('Still failing')),
         ]);
 
         expect($handled->isFail())->toBeTrue();
@@ -124,6 +122,6 @@ describe('DataTaggedError and Cause integration', function () {
     });
 
     it('throws when named constructor is used without a subclass CODE constant', function () {
-        expect(fn() => MissingCodeReviewError::from('Missing code'))->toThrow(LogicException::class);
+        expect(fn () => MissingCodeReviewError::from('Missing code'))->toThrow(LogicException::class);
     });
 });

--- a/tests/ResultErrorCauseTest.php
+++ b/tests/ResultErrorCauseTest.php
@@ -67,14 +67,14 @@ describe('DataTaggedError and Cause integration', function () {
         $out = $result->matchError([
             ReviewTestError::class => function ($e, array $meta) {
                 return $meta['request_id'];
-            }
-        ], fn() => 'ok', fn() => 'unhandled');
+            },
+        ], fn () => 'ok', fn () => 'unhandled');
 
         expect($out)->toBe('r-42');
     });
 
     it('matchError supports onSuccess with zero arguments', function () {
-        $out = Result::ok('value')->matchError([], onSuccess: fn() => 'no-arg', onUnhandled: fn() => 'uh');
+        $out = Result::ok('value')->matchError([], onSuccess: fn () => 'no-arg', onUnhandled: fn () => 'uh');
 
         expect($out)->toBe('no-arg');
     });
@@ -83,7 +83,7 @@ describe('DataTaggedError and Cause integration', function () {
         $result = Result::fail(ReviewTestError::from('Recover me'));
 
         $recovered = $result->catchError([
-            ReviewTestError::class => fn() => 'recovered-no-arg',
+            ReviewTestError::class => fn () => 'recovered-no-arg',
         ]);
 
         expect($recovered->isOk())->toBeTrue();
@@ -93,7 +93,7 @@ describe('DataTaggedError and Cause integration', function () {
     it('catchError fallback may be zero-arg and handle legacy failures', function () {
         $result = Result::fail('legacy-error');
 
-        $handled = $result->catchError([], fn() => 'fallback-no-arg');
+        $handled = $result->catchError([], fn () => 'fallback-no-arg');
 
         expect($handled->isOk())->toBeTrue();
         expect($handled->value())->toBe('fallback-no-arg');

--- a/tests/ResultErrorCauseTest.php
+++ b/tests/ResultErrorCauseTest.php
@@ -38,7 +38,7 @@ describe('DataTaggedError and Cause integration', function () {
     });
 
     it('provides debug fields including error_code and message', function () {
-        $err = new DataTaggedError('E_X', 'Something broke', null);
+        $err = new DataTaggedError('E_X', 'Something broke');
         $result = Result::fail($err);
 
         $debug = $result->toDebugArray();
@@ -48,26 +48,22 @@ describe('DataTaggedError and Cause integration', function () {
     });
 
     it('can match by error class using matchError', function () {
-        $err = new ReviewTestError('E_HANDLE', 'Handle me', null);
+        $err = new ReviewTestError('E_HANDLE', 'Handle me');
         $result = Result::fail($err);
 
         $out = $result->matchError([
-            ReviewTestError::class => function ($e) {
-                return 'handled:' . $e->code();
-            },
-        ], fn($v) => 'ok', fn($e) => 'unhandled');
+            ReviewTestError::class => fn ($e) => 'handled:'.$e->code(),
+        ], fn ($v) => 'ok', fn ($e) => 'unhandled');
 
         expect($out)->toBe('handled:E_HANDLE');
     });
 
     it('matchError passes metadata to matched handler when accepted', function () {
-        $err = new ReviewTestError('E_META', 'Has meta', null);
+        $err = new ReviewTestError('E_META', 'Has meta');
         $result = Result::fail($err, ['request_id' => 'r-42']);
 
         $out = $result->matchError([
-            ReviewTestError::class => function ($e, array $meta) {
-                return $meta['request_id'];
-            },
+            ReviewTestError::class => fn ($e, array $meta) => $meta['request_id'],
         ], fn () => 'ok', fn () => 'unhandled');
 
         expect($out)->toBe('r-42');
@@ -112,7 +108,7 @@ describe('DataTaggedError and Cause integration', function () {
         $result = Result::fail(ReviewTestError::from('Recover me'));
 
         $recovered = $result->catchError([
-            ReviewTestError::class => fn(ReviewTestError $e) => 'recovered:' . $e->code(),
+            ReviewTestError::class => fn (ReviewTestError $e) => 'recovered:'.$e->code(),
         ]);
 
         expect($recovered->isOk())->toBeTrue();
@@ -123,7 +119,7 @@ describe('DataTaggedError and Cause integration', function () {
         $result = Result::fail(AnotherReviewTestError::from('No handler'));
 
         $unchanged = $result->catchError([
-            ReviewTestError::class => fn(ReviewTestError $e) => 'wrong',
+            ReviewTestError::class => fn (ReviewTestError $e) => 'wrong',
         ]);
 
         expect($unchanged->isFail())->toBeTrue();
@@ -134,8 +130,8 @@ describe('DataTaggedError and Cause integration', function () {
         $result = Result::fail('legacy-error');
 
         $handled = $result->catchError([
-            ReviewTestError::class => fn(ReviewTestError $e) => 'wrong',
-        ], fn($error) => 'fallback:' . $error);
+            ReviewTestError::class => fn (ReviewTestError $e) => 'wrong',
+        ], fn ($error) => 'fallback:'.$error);
 
         expect($handled->isOk())->toBeTrue();
         expect($handled->value())->toBe('fallback:legacy-error');
@@ -145,7 +141,7 @@ describe('DataTaggedError and Cause integration', function () {
         $result = Result::fail(ReviewTestError::from('Refail'));
 
         $handled = $result->catchError([
-            ReviewTestError::class => fn(ReviewTestError $e) => Result::fail(AnotherReviewTestError::from('Still failing')),
+            ReviewTestError::class => fn (ReviewTestError $e) => Result::fail(AnotherReviewTestError::from('Still failing')),
         ]);
 
         expect($handled->isFail())->toBeTrue();
@@ -161,6 +157,6 @@ describe('DataTaggedError and Cause integration', function () {
     });
 
     it('throws when named constructor is used without a subclass CODE constant', function () {
-        expect(fn() => MissingCodeReviewError::from('Missing code'))->toThrow(LogicException::class);
+        expect(fn () => MissingCodeReviewError::from('Missing code'))->toThrow(LogicException::class);
     });
 });

--- a/tests/ResultErrorCauseTest.php
+++ b/tests/ResultErrorCauseTest.php
@@ -60,6 +60,45 @@ describe('DataTaggedError and Cause integration', function () {
         expect($out)->toBe('handled:E_HANDLE');
     });
 
+    it('matchError passes metadata to matched handler when accepted', function () {
+        $err = new ReviewTestError('E_META', 'Has meta', null);
+        $result = Result::fail($err, ['request_id' => 'r-42']);
+
+        $out = $result->matchError([
+            ReviewTestError::class => function ($e, array $meta) {
+                return $meta['request_id'];
+            }
+        ], fn() => 'ok', fn() => 'unhandled');
+
+        expect($out)->toBe('r-42');
+    });
+
+    it('matchError supports onSuccess with zero arguments', function () {
+        $out = Result::ok('value')->matchError([], onSuccess: fn() => 'no-arg', onUnhandled: fn() => 'uh');
+
+        expect($out)->toBe('no-arg');
+    });
+
+    it('catchError handlers may be zero-arg and return plain values', function () {
+        $result = Result::fail(ReviewTestError::from('Recover me'));
+
+        $recovered = $result->catchError([
+            ReviewTestError::class => fn() => 'recovered-no-arg',
+        ]);
+
+        expect($recovered->isOk())->toBeTrue();
+        expect($recovered->value())->toBe('recovered-no-arg');
+    });
+
+    it('catchError fallback may be zero-arg and handle legacy failures', function () {
+        $result = Result::fail('legacy-error');
+
+        $handled = $result->catchError([], fn() => 'fallback-no-arg');
+
+        expect($handled->isOk())->toBeTrue();
+        expect($handled->value())->toBe('fallback-no-arg');
+    });
+
     it('throwIfFail throws the DataTaggedError (it is Throwable)', function () {
         $err = new DataTaggedError('E_THROW', 'Throw me');
         $result = Result::fail($err);

--- a/tests/ResultErrorCauseTest.php
+++ b/tests/ResultErrorCauseTest.php
@@ -53,9 +53,9 @@ describe('DataTaggedError and Cause integration', function () {
 
         $out = $result->matchError([
             ReviewTestError::class => function ($e) {
-                return 'handled:'.$e->code();
+                return 'handled:' . $e->code();
             },
-        ], fn ($v) => 'ok', fn ($e) => 'unhandled');
+        ], fn($v) => 'ok', fn($e) => 'unhandled');
 
         expect($out)->toBe('handled:E_HANDLE');
     });
@@ -112,7 +112,7 @@ describe('DataTaggedError and Cause integration', function () {
         $result = Result::fail(ReviewTestError::from('Recover me'));
 
         $recovered = $result->catchError([
-            ReviewTestError::class => fn (ReviewTestError $e) => 'recovered:'.$e->code(),
+            ReviewTestError::class => fn(ReviewTestError $e) => 'recovered:' . $e->code(),
         ]);
 
         expect($recovered->isOk())->toBeTrue();
@@ -123,7 +123,7 @@ describe('DataTaggedError and Cause integration', function () {
         $result = Result::fail(AnotherReviewTestError::from('No handler'));
 
         $unchanged = $result->catchError([
-            ReviewTestError::class => fn (ReviewTestError $e) => 'wrong',
+            ReviewTestError::class => fn(ReviewTestError $e) => 'wrong',
         ]);
 
         expect($unchanged->isFail())->toBeTrue();
@@ -134,8 +134,8 @@ describe('DataTaggedError and Cause integration', function () {
         $result = Result::fail('legacy-error');
 
         $handled = $result->catchError([
-            ReviewTestError::class => fn (ReviewTestError $e) => 'wrong',
-        ], fn ($error) => 'fallback:'.$error);
+            ReviewTestError::class => fn(ReviewTestError $e) => 'wrong',
+        ], fn($error) => 'fallback:' . $error);
 
         expect($handled->isOk())->toBeTrue();
         expect($handled->value())->toBe('fallback:legacy-error');
@@ -145,7 +145,7 @@ describe('DataTaggedError and Cause integration', function () {
         $result = Result::fail(ReviewTestError::from('Refail'));
 
         $handled = $result->catchError([
-            ReviewTestError::class => fn (ReviewTestError $e) => Result::fail(AnotherReviewTestError::from('Still failing')),
+            ReviewTestError::class => fn(ReviewTestError $e) => Result::fail(AnotherReviewTestError::from('Still failing')),
         ]);
 
         expect($handled->isFail())->toBeTrue();
@@ -161,6 +161,6 @@ describe('DataTaggedError and Cause integration', function () {
     });
 
     it('throws when named constructor is used without a subclass CODE constant', function () {
-        expect(fn () => MissingCodeReviewError::from('Missing code'))->toThrow(LogicException::class);
+        expect(fn() => MissingCodeReviewError::from('Missing code'))->toThrow(LogicException::class);
     });
 });


### PR DESCRIPTION
## Structured Domain Errors: `DataTaggedError`, `matchError`, `catchError`, and `failTagged`

Introduces first-class support for structured domain errors in ResultFlow via a new `ResultError` interface, `DataTaggedError` base class, `Cause` value object, and two new matching methods.

### New error infrastructure

- `ResultError` interface defines a stable contract: `code()`, `message()`, `payload()`, `cause()`, and `toArray()`.
- `DataTaggedError` extends `RuntimeException` and implements `ResultError`. Subclasses define a `CODE` constant and are constructed via `::from(...)` for ergonomic named domain errors.
- `Cause` is a lightweight nested value object for representing error cause chains without exception overhead.

### New `Result` methods

- `Result::failTagged(string $code, string $message, mixed $payload, array $meta, ?Cause $cause)` — creates a structured failure without requiring a named subclass.
- `matchError(array $errorHandlers, callable $onSuccess, callable $onUnhandled)` — finalizes a `Result` by dispatching on `ResultError` class. Handlers are checked in array order; the first matching class wins. Callbacks support flexible arity: error only, or error plus metadata.
- `catchError(array $handlers, ?callable $fallback)` — recovers or re-fails structured errors while staying inside the `Result` flow. Handlers and fallback may return a plain value or a `Result`.

### Serialization and debug improvements

- `toArray()` now normalizes `ResultError` failures through `toArray()` before output.
- `toDebugArray()` gains an `error_code` field populated from `ResultError::code()`.

### Documentation

- Reference pages for construction, failure handling, and boundaries updated with signatures, behavior notes, and examples for `failTagged`, `matchError`, and `catchError`.
- Kitchen-sink pages updated with quick-map entries and full method sections.
- Failure handling concept page and error normalization guide updated with structured error patterns.
- Boost guidelines, skill references, and public API whitelist updated to include all new APIs.

### Tests and examples

- `tests/ResultErrorCauseTest.php` covers serialization, debug output, `matchError`, `catchError`, fallback behavior, cause chaining, named constructor validation, and `throwIfFail` compatibility.
- `examples/tagged-error-demo.php` demonstrates named error subclasses, nested `Cause`, `matchError`, and `catchError` across persist, validation, and success paths.

### CI

- PHP 8.5 added to the test matrix.