### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,10 @@
 ## Release hygiene
 - Releases update `CHANGELOG.md` via GitHub workflows.
 - Avoid changing package version metadata in PRs.
+
+## Cursor Cloud specific instructions
+- Two toolchains are used: PHP (CLI `php`, `composer`) for the library, and Node/`pnpm` for the VitePress docs site. The VM has PHP 8.4 as the default `php` (matches the PHPStan CI job; the test matrix also covers 8.2/8.3).
+- Dependencies are refreshed automatically on startup via the update script (`composer install`, `pnpm install --frozen-lockfile`). No manual install needed; standard commands live in `## Quality checks` and `README.md`.
+- No `composer.lock` is committed, so `composer install` resolves the latest allowed dev tools. Newer PHPStan/Rector releases can surface findings that were not present when CI last ran on `main` (e.g. `composer analyse` reporting `isset.offset` / `alreadyNarrowedType` / `ignore.unmatchedIdentifier`, and `composer rector-dry` proposing `declare(strict_types=1)` additions). These are upstream tool drift, not repo regressions; do not "fix" them as part of unrelated work. `composer test` and `composer pint-test` pass cleanly.
+- Run library examples directly, e.g. `php examples/construction/of-defer-demo.php` (each script bootstraps `vendor/autoload.php`).
+- Docs dev server: `pnpm run docs:dev` serves under the base path `/result-flow/` (i.e. `http://127.0.0.1:5173/result-flow/`, not the bare root).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the development environment for this repository (PHP library + VitePress docs) and documents non-obvious startup notes for future cloud agents.

- Installs PHP 8.4 (matches the PHPStan CI job; test matrix also covers 8.2/8.3) + Composer, and Node/`pnpm` deps.
- Update script (registered separately): `composer install` + `pnpm install --frozen-lockfile`.
- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md`.

No source code changed.

## Verification
- `composer test` → 203 passed (444 assertions)
- `composer pint-test` → passed
- `php examples/construction/of-defer-demo.php` → runs end-to-end
- VitePress docs dev server serves at `/result-flow/` (HTTP 200)

## Notes
No `composer.lock` is committed, so `composer install` resolves the latest allowed dev tools. Newer PHPStan/Rector releases surface findings (`composer analyse`, `composer rector-dry`) that were not present when CI last ran green on `main`. These are upstream tool drift, not repo regressions, and are documented in `AGENTS.md`.

[vitepress_docs_demo.mp4](https://cursor.com/agents/bc-980904c1-2347-469e-b827-be93a161f59c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvitepress_docs_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-980904c1-2347-469e-b827-be93a161f59c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-980904c1-2347-469e-b827-be93a161f59c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

